### PR TITLE
Skip crashing and hanging tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For the `react-native-wgpu` library, there are a few blockers for generating a f
 
 - `webgpu/api/operation/adapter`: Main thread hangs on a promise await. See: https://github.com/wcandillon/react-native-webgpu/issues/126
 - `webgpu/api/operation/buffers`: `map.spec` and `map_oom.spec` have tests that crash when trying to allocate a buffer. `remapped_for_write`, `mappedAtCreation,mapState`, `mapAsync,mapState`, `mappedAtCreation`.
+- `webgpu/api/operation/command_buffer`: Tests with compressed texture formats seem to hang indefinitely (e.g. astc-4x4-unorm).
 - `webgpu/api/operation/memory_sync`: The "either" interpolation option is not supported, causing shader compilation to crash. Shader compilation crashes should likely not crash the app.
 - `webgpu/api/operation/render_pipeline`: Tests crash with an unknown error.
 - `webgpu/api/operation/rendering`: Same as `memory_sync` tests.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,19 @@ To install dependencies for the conformance test suite, run the following comman
 npm install
 ```
 
+For ios:
+
+```
+pod install --project-directory=ios
+```
+
 The React Native portion of this test suite is built on top of [React Native Test App](https://github.com/microsoft/react-native-test-app). Build instructions for your target platform can be found here: https://github.com/microsoft/react-native-test-app/wiki/Quick-Start#platform-specific-instructions. The conformance test suite targets Hermes by default.
+
+To run on an ios simulator, run:
+
+```
+npm run ios
+```
 
 To run tests, click the "Run Tests" button on the app homepage. Once tests complete, the app will generate a summary of failed and skipped tests, along with a list of all tests that failed. The tests will take a few minutes to run. A log of the current running test can be viewed in the Metro console.
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ For the `react-native-wgpu` library, there are a few blockers for generating a f
 
 - `webgpu/api/operation/adapter`: Main thread hangs on a promise await. See: https://github.com/wcandillon/react-native-webgpu/issues/126
 - `webgpu/api/operation/buffers`: `map.spec` and `map_oom.spec` have tests that crash when trying to allocate a buffer. `remapped_for_write`, `mappedAtCreation,mapState`, `mapAsync,mapState`, `mappedAtCreation`.
-- `webgpu/api/operation/command_buffer`: Tests with compressed texture formats seem to hang indefinitely (e.g. astc-4x4-unorm).
+- `webgpu/api/operation/command_buffer`: Tests with compressed texture formats seem to hang indefinitely (e.g. astc-4x4-unorm). Tests following the copyTextureToTexture tests all seem to time out, possibly due to the depth32float_stencil8 format.
 - `webgpu/api/operation/memory_sync`: The "either" interpolation option is not supported, causing shader compilation to crash. Shader compilation crashes should likely not crash the app.
-- `webgpu/api/operation/render_pipeline`: Tests crash with an unknown error.
+- `webgpu/api/operation/render_pipeline`: Tests crash with an unknown error in `pipeline_output_targets.spec`.
 - `webgpu/api/operation/rendering`: Same as `memory_sync` tests.
 - `webgpu/api/operation/shader_module`: Different shader compilation issue.
 - `webgpu/api/operation/storage_texture`: Same as `memory_sync` tests.
 - `webgpu/api/operation/vertex_state`: Same as `memory_sync` tests.
+- `webgpu/api/operation/reflection`: Attribute tests crash.
 
 ## Contributing
 

--- a/src/app/runTests.ts
+++ b/src/app/runTests.ts
@@ -1,3 +1,4 @@
+import { globalTestConfig } from '../common/framework/test_config';
 import { DefaultTestFileLoader } from '../common/internal/file_loader';
 import { Logger } from '../common/internal/logging/logger';
 import { LiveTestCaseResult } from '../common/internal/logging/result';
@@ -6,6 +7,8 @@ import { parseExpectationsForTestQuery } from '../common/internal/query/query';
 import { assert, unreachable } from '../common/util/util';
 
 const filterQuery = 'webgpu:api,operation,*';
+
+globalTestConfig.compatibility = true;
 
 export const runTests = async () => {
   const loader = new DefaultTestFileLoader();
@@ -27,7 +30,7 @@ export const runTests = async () => {
     console.log(name);
     const [rec, res] = log.record(name);
     await testcase.run(rec, expectations);
-    if (res.status === 'fail') {
+    if (res.status === 'fail' || res.status === 'skip') {
       console.log(res.logs);
     }
 

--- a/src/app/runTests.ts
+++ b/src/app/runTests.ts
@@ -1,5 +1,4 @@
 import { DefaultTestFileLoader } from '../common/internal/file_loader';
-import { LogMessageWithStack } from '../common/internal/logging/log_message';
 import { Logger } from '../common/internal/logging/logger';
 import { LiveTestCaseResult } from '../common/internal/logging/result';
 import { parseQuery } from '../common/internal/query/parseQuery';
@@ -7,9 +6,6 @@ import { parseExpectationsForTestQuery } from '../common/internal/query/query';
 import { assert, unreachable } from '../common/util/util';
 
 const filterQuery = 'webgpu:api,operation,*';
-
-// Time out tests after a delay
-const TEST_TIMEOUT = 5000;
 
 export const runTests = async () => {
   const loader = new DefaultTestFileLoader();
@@ -30,8 +26,7 @@ export const runTests = async () => {
 
     console.log(name);
     const [rec, res] = log.record(name);
-    const timeout = createTimeout(res, TEST_TIMEOUT);
-    await Promise.race([testcase.run(rec, expectations), timeout]);
+    await testcase.run(rec, expectations);
     if (res.status === 'fail') {
       console.log(res.logs);
     }
@@ -62,19 +57,4 @@ export const runTests = async () => {
     warned,
     skipped,
   };
-};
-
-const createTimeout = (res: LiveTestCaseResult, timeoutLength: number) => {
-  return new Promise<void>(resolve => {
-    setTimeout(() => {
-      res.status = 'fail';
-      res.logs = [
-        LogMessageWithStack.wrapError(
-          'timeout',
-          new Error(`Manually timed out test after ${timeoutLength} ms.`)
-        ),
-      ];
-      resolve();
-    }, timeoutLength);
-  });
 };

--- a/src/app/runTests.ts
+++ b/src/app/runTests.ts
@@ -8,8 +8,8 @@ import { assert, unreachable } from '../common/util/util';
 
 const filterQuery = 'webgpu:api,operation,*';
 
-// Time out tests after 1 minute
-const TEST_TIMEOUT = 60000;
+// Time out tests after a delay
+const TEST_TIMEOUT = 5000;
 
 export const runTests = async () => {
   const loader = new DefaultTestFileLoader();

--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -158,7 +158,8 @@ export class Fixture<S extends SubcaseBatchState = SubcaseBatchState> {
       this.objectsToCleanUp.push({
         async destroyAsync() {
           o.destroy();
-          await o.lost;
+          // TODO FIXME: awaiting device.lost a second time causes promise to hang
+          // await o.lost;
         },
       });
     } else {

--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -1,6 +1,11 @@
 import { TestCaseRecorder } from '../internal/logging/test_case_recorder.js';
 import { JSONWithUndefined } from '../internal/params_utils.js';
-import { assert, ExceptionCheckOptions, unreachable } from '../util/util.js';
+import {
+  assert,
+  ExceptionCheckOptions,
+  raceWithRejectOnTimeout,
+  unreachable,
+} from '../util/util.js';
 
 export class SkipTestCase extends Error {}
 export class UnexpectedPassError extends Error {}
@@ -113,7 +118,7 @@ export class Fixture<S extends SubcaseBatchState = SubcaseBatchState> {
     while (this.eventualExpectations.length) {
       const p = this.eventualExpectations.shift()!;
       try {
-        await p;
+        await raceWithRejectOnTimeout(p, 1000, 'Eventual expectation timed out');
       } catch (ex) {
         this.rec.threw(ex);
       }

--- a/src/webgpu/api/operation/buffers/map.spec.ts
+++ b/src/webgpu/api/operation/buffers/map.spec.ts
@@ -330,37 +330,39 @@ still present in the mapped buffer.`
       .combineWithParams(kSubcases)
   )
   .fn(async t => {
-    const { size, range, mappedAtCreation } = t.params;
-    const [rangeOffset, rangeSize] = reifyMapRange(size, range);
+    t.fail('Test causes crash');
 
-    const buffer = t.createBufferTracked({
-      mappedAtCreation,
-      size,
-      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
-    });
+    // const { size, range, mappedAtCreation } = t.params;
+    // const [rangeOffset, rangeSize] = reifyMapRange(size, range);
 
-    // If the buffer is not mappedAtCreation map it now.
-    if (!mappedAtCreation) {
-      await buffer.mapAsync(GPUMapMode.WRITE);
-    }
+    // const buffer = t.createBufferTracked({
+    //   mappedAtCreation,
+    //   size,
+    //   usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+    // });
 
-    // Set the initial contents of the buffer.
-    const init = buffer.getMappedRange(...range);
+    // // If the buffer is not mappedAtCreation map it now.
+    // if (!mappedAtCreation) {
+    //   await buffer.mapAsync(GPUMapMode.WRITE);
+    // }
 
-    assert(init.byteLength === rangeSize);
-    const expected = new Uint32Array(new ArrayBuffer(rangeSize));
-    const data = new Uint32Array(init);
-    for (let i = 0; i < data.length; ++i) {
-      data[i] = expected[i] = i + 1;
-    }
-    buffer.unmap();
+    // // Set the initial contents of the buffer.
+    // const init = buffer.getMappedRange(...range);
 
-    // Check that upon remapping the for WRITE the values in the buffer are
-    // still the same.
-    const mapRegion = getRegionForMap(size, [rangeOffset, rangeSize], t.params);
-    await buffer.mapAsync(GPUMapMode.WRITE, ...mapRegion);
-    const actual = new Uint8Array(buffer.getMappedRange(...range));
-    t.expectOK(checkElementsEqual(actual, new Uint8Array(expected.buffer)));
+    // assert(init.byteLength === rangeSize);
+    // const expected = new Uint32Array(new ArrayBuffer(rangeSize));
+    // const data = new Uint32Array(init);
+    // for (let i = 0; i < data.length; ++i) {
+    //   data[i] = expected[i] = i + 1;
+    // }
+    // buffer.unmap();
+
+    // // Check that upon remapping the for WRITE the values in the buffer are
+    // // still the same.
+    // const mapRegion = getRegionForMap(size, [rangeOffset, rangeSize], t.params);
+    // await buffer.mapAsync(GPUMapMode.WRITE, ...mapRegion);
+    // const actual = new Uint8Array(buffer.getMappedRange(...range));
+    // t.expectOK(checkElementsEqual(actual, new Uint8Array(expected.buffer)));
   });
 
 g.test('mappedAtCreation,mapState')
@@ -372,42 +374,43 @@ g.test('mappedAtCreation,mapState')
       .combine('afterDestroy', [false, true])
   )
   .fn(t => {
-    const { usageType, afterUnmap, afterDestroy } = t.params;
-    const usage =
-      usageType === 'read'
-        ? GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
-        : usageType === 'write'
-        ? GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
-        : 0;
-    const validationError = usage === 0;
-    const size = 8;
-    const range = [0, 8];
+    t.fail('Test causes crash');
+    // const { usageType, afterUnmap, afterDestroy } = t.params;
+    // const usage =
+    //   usageType === 'read'
+    //     ? GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+    //     : usageType === 'write'
+    //     ? GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+    //     : 0;
+    // const validationError = usage === 0;
+    // const size = 8;
+    // const range = [0, 8];
 
-    let buffer: GPUBuffer;
-    t.expectValidationError(() => {
-      buffer = t.createBufferTracked({
-        mappedAtCreation: true,
-        size,
-        usage,
-      });
-    }, validationError);
+    // let buffer: GPUBuffer;
+    // t.expectValidationError(() => {
+    //   buffer = t.createBufferTracked({
+    //     mappedAtCreation: true,
+    //     size,
+    //     usage,
+    //   });
+    // }, validationError);
 
-    // mapState must be "mapped" regardless of validation error
-    t.expect(buffer!.mapState === 'mapped');
+    // // mapState must be "mapped" regardless of validation error
+    // t.expect(buffer!.mapState === 'mapped');
 
-    // getMappedRange must not change the map state
-    buffer!.getMappedRange(...range);
-    t.expect(buffer!.mapState === 'mapped');
+    // // getMappedRange must not change the map state
+    // buffer!.getMappedRange(...range);
+    // t.expect(buffer!.mapState === 'mapped');
 
-    if (afterUnmap) {
-      buffer!.unmap();
-      t.expect(buffer!.mapState === 'unmapped');
-    }
+    // if (afterUnmap) {
+    //   buffer!.unmap();
+    //   t.expect(buffer!.mapState === 'unmapped');
+    // }
 
-    if (afterDestroy) {
-      buffer!.destroy();
-      t.expect(buffer!.mapState === 'unmapped');
-    }
+    // if (afterDestroy) {
+    //   buffer!.destroy();
+    //   t.expect(buffer!.mapState === 'unmapped');
+    // }
   });
 
 g.test('mapAsync,mapState')
@@ -422,89 +425,90 @@ g.test('mapAsync,mapState')
       .combine('afterDestroy', [false, true])
   )
   .fn(async t => {
-    const { usageType, mapModeType, beforeUnmap, beforeDestroy, afterUnmap, afterDestroy } =
-      t.params;
-    const size = 8;
-    const range = [0, 8];
-    const usage =
-      usageType === 'read'
-        ? GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
-        : usageType === 'write'
-        ? GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
-        : 0;
-    const bufferCreationValidationError = usage === 0;
-    const mapMode = GPUMapMode[mapModeType];
+    t.fail('Test causes crash');
+    // const { usageType, mapModeType, beforeUnmap, beforeDestroy, afterUnmap, afterDestroy } =
+    //   t.params;
+    // const size = 8;
+    // const range = [0, 8];
+    // const usage =
+    //   usageType === 'read'
+    //     ? GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+    //     : usageType === 'write'
+    //     ? GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+    //     : 0;
+    // const bufferCreationValidationError = usage === 0;
+    // const mapMode = GPUMapMode[mapModeType];
 
-    let buffer: GPUBuffer;
-    t.expectValidationError(() => {
-      buffer = t.createBufferTracked({
-        mappedAtCreation: false,
-        size,
-        usage,
-      });
-    }, bufferCreationValidationError);
+    // let buffer: GPUBuffer;
+    // t.expectValidationError(() => {
+    //   buffer = t.createBufferTracked({
+    //     mappedAtCreation: false,
+    //     size,
+    //     usage,
+    //   });
+    // }, bufferCreationValidationError);
 
-    t.expect(buffer!.mapState === 'unmapped');
+    // t.expect(buffer!.mapState === 'unmapped');
 
-    {
-      const mapAsyncValidationError =
-        bufferCreationValidationError ||
-        (mapMode === GPUMapMode.READ && !(usage & GPUBufferUsage.MAP_READ)) ||
-        (mapMode === GPUMapMode.WRITE && !(usage & GPUBufferUsage.MAP_WRITE));
-      let promise: Promise<void>;
-      t.expectValidationError(() => {
-        promise = buffer!.mapAsync(mapMode);
-      }, mapAsyncValidationError);
-      t.expect(buffer!.mapState === 'pending');
+    // {
+    //   const mapAsyncValidationError =
+    //     bufferCreationValidationError ||
+    //     (mapMode === GPUMapMode.READ && !(usage & GPUBufferUsage.MAP_READ)) ||
+    //     (mapMode === GPUMapMode.WRITE && !(usage & GPUBufferUsage.MAP_WRITE));
+    //   let promise: Promise<void>;
+    //   t.expectValidationError(() => {
+    //     promise = buffer!.mapAsync(mapMode);
+    //   }, mapAsyncValidationError);
+    //   t.expect(buffer!.mapState === 'pending');
 
-      try {
-        if (beforeUnmap) {
-          buffer!.unmap();
-          t.expect(buffer!.mapState === 'unmapped');
-        }
-        if (beforeDestroy) {
-          buffer!.destroy();
-          t.expect(buffer!.mapState === 'unmapped');
-        }
+    //   try {
+    //     if (beforeUnmap) {
+    //       buffer!.unmap();
+    //       t.expect(buffer!.mapState === 'unmapped');
+    //     }
+    //     if (beforeDestroy) {
+    //       buffer!.destroy();
+    //       t.expect(buffer!.mapState === 'unmapped');
+    //     }
 
-        await promise!;
-        t.expect(buffer!.mapState === 'mapped');
+    //     await promise!;
+    //     t.expect(buffer!.mapState === 'mapped');
 
-        // getMappedRange must not change the map state
-        buffer!.getMappedRange(...range);
-        t.expect(buffer!.mapState === 'mapped');
-      } catch {
-        // unmapped before resolve, destroyed before resolve, or mapAsync validation error
-        // will end up with rejection and 'unmapped'
-        t.expect(buffer!.mapState === 'unmapped');
-      }
-    }
+    //     // getMappedRange must not change the map state
+    //     buffer!.getMappedRange(...range);
+    //     t.expect(buffer!.mapState === 'mapped');
+    //   } catch {
+    //     // unmapped before resolve, destroyed before resolve, or mapAsync validation error
+    //     // will end up with rejection and 'unmapped'
+    //     t.expect(buffer!.mapState === 'unmapped');
+    //   }
+    // }
 
-    // If buffer is already mapped test mapAsync on already mapped buffer
-    if (buffer!.mapState === 'mapped') {
-      // mapAsync on already mapped buffer must be rejected with a validation error
-      // and the map state must keep 'mapped'
-      let promise: Promise<void>;
-      t.expectValidationError(() => {
-        promise = buffer!.mapAsync(GPUMapMode.WRITE);
-      }, true);
-      t.expect(buffer!.mapState === 'mapped');
+    // // If buffer is already mapped test mapAsync on already mapped buffer
+    // if (buffer!.mapState === 'mapped') {
+    //   // mapAsync on already mapped buffer must be rejected with a validation error
+    //   // and the map state must keep 'mapped'
+    //   let promise: Promise<void>;
+    //   t.expectValidationError(() => {
+    //     promise = buffer!.mapAsync(GPUMapMode.WRITE);
+    //   }, true);
+    //   t.expect(buffer!.mapState === 'mapped');
 
-      try {
-        await promise!;
-        t.fail('mapAsync on already mapped buffer must not succeed.');
-      } catch {
-        t.expect(buffer!.mapState === 'mapped');
-      }
-    }
+    //   try {
+    //     await promise!;
+    //     t.fail('mapAsync on already mapped buffer must not succeed.');
+    //   } catch {
+    //     t.expect(buffer!.mapState === 'mapped');
+    //   }
+    // }
 
-    if (afterUnmap) {
-      buffer!.unmap();
-      t.expect(buffer!.mapState === 'unmapped');
-    }
+    // if (afterUnmap) {
+    //   buffer!.unmap();
+    //   t.expect(buffer!.mapState === 'unmapped');
+    // }
 
-    if (afterDestroy) {
-      buffer!.destroy();
-      t.expect(buffer!.mapState === 'unmapped');
-    }
+    // if (afterDestroy) {
+    //   buffer!.destroy();
+    //   t.expect(buffer!.mapState === 'unmapped');
+    // }
   });

--- a/src/webgpu/api/operation/buffers/map.spec.ts
+++ b/src/webgpu/api/operation/buffers/map.spec.ts
@@ -330,6 +330,7 @@ still present in the mapped buffer.`
       .combineWithParams(kSubcases)
   )
   .fn(async t => {
+    // TODO FIXME: t.createBufferTracked crashes
     t.fail('Test causes crash');
 
     // const { size, range, mappedAtCreation } = t.params;
@@ -374,6 +375,7 @@ g.test('mappedAtCreation,mapState')
       .combine('afterDestroy', [false, true])
   )
   .fn(t => {
+    // TODO FIXME: t.createBufferTracked crashes
     t.fail('Test causes crash');
     // const { usageType, afterUnmap, afterDestroy } = t.params;
     // const usage =
@@ -425,6 +427,7 @@ g.test('mapAsync,mapState')
       .combine('afterDestroy', [false, true])
   )
   .fn(async t => {
+    // TODO FIXME: t.createBufferTracked crashes
     t.fail('Test causes crash');
     // const { usageType, mapModeType, beforeUnmap, beforeDestroy, afterUnmap, afterDestroy } =
     //   t.params;

--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -39,6 +39,7 @@ g.test('mappedAtCreation')
     if (oom) {
       // getMappedRange is normally valid on OOM buffers, but this one fails because the
       // (default) range is too large to create the returned ArrayBuffer.
+      // TODO FIXME: t.createBufferTracked crashes
       t.fail('Test causes crash');
       // t.shouldThrow('RangeError', f);
     } else {

--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -39,7 +39,8 @@ g.test('mappedAtCreation')
     if (oom) {
       // getMappedRange is normally valid on OOM buffers, but this one fails because the
       // (default) range is too large to create the returned ArrayBuffer.
-      t.shouldThrow('RangeError', f);
+      t.fail('Test causes crash');
+      // t.shouldThrow('RangeError', f);
     } else {
       const buffer = f();
       const mapping = buffer.getMappedRange();

--- a/src/webgpu/api/operation/reflection.spec.ts
+++ b/src/webgpu/api/operation/reflection.spec.ts
@@ -41,14 +41,15 @@ g.test('buffer_reflection_attributes')
   .desc(`For every buffer attribute, the corresponding descriptor value is carried over.`)
   .paramsSubcasesOnly(u => u.combine('descriptor', kBufferSubcases))
   .fn(t => {
-    const { descriptor } = t.params;
+    t.fail('Test crashes');
+    // const { descriptor } = t.params;
 
-    t.expectValidationError(() => {
-      const buffer = t.createBufferTracked(descriptor);
+    // t.expectValidationError(() => {
+    //   const buffer = t.createBufferTracked(descriptor);
 
-      t.expect(buffer.size === descriptor.size);
-      t.expect(buffer.usage === descriptor.usage);
-    }, descriptor.invalid === true);
+    //   t.expect(buffer.size === descriptor.size);
+    //   t.expect(buffer.usage === descriptor.usage);
+    // }, descriptor.invalid === true);
   });
 
 g.test('buffer_creation_from_reflection')
@@ -146,33 +147,34 @@ g.test('texture_reflection_attributes')
   .desc(`For every texture attribute, the corresponding descriptor value is carried over.`)
   .paramsSubcasesOnly(u => u.combine('descriptor', kTextureSubcases))
   .fn(t => {
-    const { descriptor } = t.params;
+    t.fail('Test crashes');
+    // const { descriptor } = t.params;
 
-    let width: number;
-    let height: number;
-    let depthOrArrayLayers: number;
-    if (Array.isArray(descriptor.size)) {
-      width = descriptor.size[0];
-      height = descriptor.size[1] || 1;
-      depthOrArrayLayers = descriptor.size[2] || 1;
-    } else {
-      width = (descriptor.size as GPUExtent3DDict).width;
-      height = (descriptor.size as GPUExtent3DDict).height || 1;
-      depthOrArrayLayers = (descriptor.size as GPUExtent3DDict).depthOrArrayLayers || 1;
-    }
+    // let width: number;
+    // let height: number;
+    // let depthOrArrayLayers: number;
+    // if (Array.isArray(descriptor.size)) {
+    //   width = descriptor.size[0];
+    //   height = descriptor.size[1] || 1;
+    //   depthOrArrayLayers = descriptor.size[2] || 1;
+    // } else {
+    //   width = (descriptor.size as GPUExtent3DDict).width;
+    //   height = (descriptor.size as GPUExtent3DDict).height || 1;
+    //   depthOrArrayLayers = (descriptor.size as GPUExtent3DDict).depthOrArrayLayers || 1;
+    // }
 
-    t.expectValidationError(() => {
-      const texture = t.createTextureTracked(descriptor);
+    // t.expectValidationError(() => {
+    //   const texture = t.createTextureTracked(descriptor);
 
-      t.expect(texture.width === width);
-      t.expect(texture.height === height);
-      t.expect(texture.depthOrArrayLayers === depthOrArrayLayers);
-      t.expect(texture.format === descriptor.format);
-      t.expect(texture.usage === descriptor.usage);
-      t.expect(texture.dimension === (descriptor.dimension || '2d'));
-      t.expect(texture.mipLevelCount === (descriptor.mipLevelCount || 1));
-      t.expect(texture.sampleCount === (descriptor.sampleCount || 1));
-    }, descriptor.invalid === true);
+    //   t.expect(texture.width === width);
+    //   t.expect(texture.height === height);
+    //   t.expect(texture.depthOrArrayLayers === depthOrArrayLayers);
+    //   t.expect(texture.format === descriptor.format);
+    //   t.expect(texture.usage === descriptor.usage);
+    //   t.expect(texture.dimension === (descriptor.dimension || '2d'));
+    //   t.expect(texture.mipLevelCount === (descriptor.mipLevelCount || 1));
+    //   t.expect(texture.sampleCount === (descriptor.sampleCount || 1));
+    // }, descriptor.invalid === true);
   });
 
 interface TextureWithSize extends GPUTexture {
@@ -242,14 +244,15 @@ g.test('query_set_reflection_attributes')
   .desc(`For every queue attribute, the corresponding descriptor value is carried over.`)
   .paramsSubcasesOnly(u => u.combine('descriptor', kQuerySetSubcases))
   .fn(t => {
-    const { descriptor } = t.params;
+    t.fail('Test crashes');
+    // const { descriptor } = t.params;
 
-    t.expectValidationError(() => {
-      const querySet = t.createQuerySetTracked(descriptor);
+    // t.expectValidationError(() => {
+    //   const querySet = t.createQuerySetTracked(descriptor);
 
-      t.expect(querySet.type === descriptor.type);
-      t.expect(querySet.count === descriptor.count);
-    }, descriptor.invalid === true);
+    //   t.expect(querySet.type === descriptor.type);
+    //   t.expect(querySet.count === descriptor.count);
+    // }, descriptor.invalid === true);
   });
 
 g.test('query_set_creation_from_reflection')

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -61,89 +61,90 @@ g.test('color,attachments')
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
-    const { format, attachmentCount, emptyAttachmentId } = t.params;
-    const componentCount = kTexelRepresentationInfo[format].componentOrder.length;
-    const info = kTextureFormatInfo[format];
+    t.fail('Test crashes');
+    // const { format, attachmentCount, emptyAttachmentId } = t.params;
+    // const componentCount = kTexelRepresentationInfo[format].componentOrder.length;
+    // const info = kTextureFormatInfo[format];
 
-    // We only need to test formats that have a valid color attachment bytes per sample.
-    const pixelByteCost = kTextureFormatInfo[format].colorRender?.byteCost;
-    t.skipIf(
-      pixelByteCost === undefined ||
-        computeBytesPerSampleFromFormats(range(attachmentCount, () => format)) >
-          t.device.limits.maxColorAttachmentBytesPerSample
-    );
+    // // We only need to test formats that have a valid color attachment bytes per sample.
+    // const pixelByteCost = kTextureFormatInfo[format].colorRender?.byteCost;
+    // t.skipIf(
+    //   pixelByteCost === undefined ||
+    //     computeBytesPerSampleFromFormats(range(attachmentCount, () => format)) >
+    //       t.device.limits.maxColorAttachmentBytesPerSample
+    // );
 
-    const writeValues =
-      info.color.type === 'sint' || info.color.type === 'uint'
-        ? attachmentsIntWriteValues
-        : attachmentsFloatWriteValues;
+    // const writeValues =
+    //   info.color.type === 'sint' || info.color.type === 'uint'
+    //     ? attachmentsIntWriteValues
+    //     : attachmentsFloatWriteValues;
 
-    const renderTargets = range(attachmentCount, () =>
-      t.createTextureTracked({
-        format,
-        size: { width: 1, height: 1, depthOrArrayLayers: 1 },
-        usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
-      })
-    );
-    const pipeline = t.device.createRenderPipeline({
-      layout: 'auto',
-      vertex: {
-        module: t.device.createShaderModule({
-          code: kVertexShader,
-        }),
-        entryPoint: 'main',
-      },
-      fragment: {
-        module: t.device.createShaderModule({
-          code: getFragmentShaderCodeWithOutput(
-            range(attachmentCount, i =>
-              i === emptyAttachmentId
-                ? null
-                : {
-                    values: [
-                      writeValues[i].R,
-                      writeValues[i].G,
-                      writeValues[i].B,
-                      writeValues[i].A,
-                    ],
-                    plainType: getPlainTypeInfo(info.color.type),
-                    componentCount,
-                  }
-            )
-          ),
-        }),
-        entryPoint: 'main',
-        targets: range(attachmentCount, i => (i === emptyAttachmentId ? null : { format })),
-      },
-      primitive: { topology: 'triangle-list' },
-    });
+    // const renderTargets = range(attachmentCount, () =>
+    //   t.createTextureTracked({
+    //     format,
+    //     size: { width: 1, height: 1, depthOrArrayLayers: 1 },
+    //     usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    //   })
+    // );
+    // const pipeline = t.device.createRenderPipeline({
+    //   layout: 'auto',
+    //   vertex: {
+    //     module: t.device.createShaderModule({
+    //       code: kVertexShader,
+    //     }),
+    //     entryPoint: 'main',
+    //   },
+    //   fragment: {
+    //     module: t.device.createShaderModule({
+    //       code: getFragmentShaderCodeWithOutput(
+    //         range(attachmentCount, i =>
+    //           i === emptyAttachmentId
+    //             ? null
+    //             : {
+    //                 values: [
+    //                   writeValues[i].R,
+    //                   writeValues[i].G,
+    //                   writeValues[i].B,
+    //                   writeValues[i].A,
+    //                 ],
+    //                 plainType: getPlainTypeInfo(info.color.type),
+    //                 componentCount,
+    //               }
+    //         )
+    //       ),
+    //     }),
+    //     entryPoint: 'main',
+    //     targets: range(attachmentCount, i => (i === emptyAttachmentId ? null : { format })),
+    //   },
+    //   primitive: { topology: 'triangle-list' },
+    // });
 
-    const encoder = t.device.createCommandEncoder();
-    const pass = encoder.beginRenderPass({
-      colorAttachments: range(attachmentCount, i =>
-        i === emptyAttachmentId
-          ? null
-          : {
-              view: renderTargets[i].createView(),
-              clearValue: { r: 0.5, g: 0.5, b: 0.5, a: 0.5 },
-              loadOp: 'clear',
-              storeOp: 'store',
-            }
-      ),
-    });
-    pass.setPipeline(pipeline);
-    pass.draw(3);
-    pass.end();
-    t.device.queue.submit([encoder.finish()]);
+    // const encoder = t.device.createCommandEncoder();
+    // const pass = encoder.beginRenderPass({
+    //   colorAttachments: range(attachmentCount, i =>
+    //     i === emptyAttachmentId
+    //       ? null
+    //       : {
+    //           view: renderTargets[i].createView(),
+    //           clearValue: { r: 0.5, g: 0.5, b: 0.5, a: 0.5 },
+    //           loadOp: 'clear',
+    //           storeOp: 'store',
+    //         }
+    //   ),
+    // });
+    // pass.setPipeline(pipeline);
+    // pass.draw(3);
+    // pass.end();
+    // t.device.queue.submit([encoder.finish()]);
 
-    for (let i = 0; i < attachmentCount; i++) {
-      if (i === emptyAttachmentId) {
-        continue;
-      }
-      t.expectSinglePixelComparisonsAreOkInTexture({ texture: renderTargets[i] }, [
-        { coord: { x: 0, y: 0 }, exp: writeValues[i] },
-      ]);
-    }
+    // for (let i = 0; i < attachmentCount; i++) {
+    //   if (i === emptyAttachmentId) {
+    //     continue;
+    //   }
+    //   t.expectSinglePixelComparisonsAreOkInTexture({ texture: renderTargets[i] }, [
+    //     { coord: { x: 0, y: 0 }, exp: writeValues[i] },
+    //   ]);
+    // }
   });
 
 g.test('color,component_count')

--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -84,7 +84,7 @@ export class DevicePool {
         if ('destroy' in holder.device) {
           holder.device.destroy();
           // Wait for destruction (or actual device loss if any) to complete.
-          await holder.device.lost;
+          // await holder.device.lost;
         }
 
         // Release the (hopefully only) ref to the GPUDevice.


### PR DESCRIPTION
## Changes
- Automatically fails tests that crash within the buffer test suite
- Enable compatibility mode to skip texture compression tests that appear to be unsupported
- Resolve an issue where calling device.lost twice causes the tests to hang