### PR TITLE
Run all tests to completion on iOS simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ For the `react-native-wgpu` library, there are a few blockers for generating a f
 - `webgpu/api/operation/adapter`: Main thread hangs on a promise await. See: https://github.com/wcandillon/react-native-webgpu/issues/126
 - `webgpu/api/operation/buffers`: `map.spec` and `map_oom.spec` have tests that crash when trying to allocate a buffer. `remapped_for_write`, `mappedAtCreation,mapState`, `mapAsync,mapState`, `mappedAtCreation`.
 - `webgpu/api/operation/command_buffer`: Tests with compressed texture formats seem to hang indefinitely (e.g. astc-4x4-unorm). Tests following the copyTextureToTexture tests all seem to time out, possibly due to the depth32float_stencil8 format.
-- `webgpu/api/operation/memory_sync`: The "either" interpolation option is not supported, causing shader compilation to crash. Shader compilation crashes should likely not crash the app.
+- `webgpu/api/operation/memory_sync`: The "either" interpolation option is not supported, causing shader compilation to crash. Shader compilation crashes should likely not crash the app. Tests run to completion when Dawn is updated to v6592+.
 - `webgpu/api/operation/render_pipeline`: Tests crash with an unknown error in `pipeline_output_targets.spec`.
-- `webgpu/api/operation/rendering`: Same as `memory_sync` tests.
+- `webgpu/api/operation/rendering`: Same shader compilation issue as `memory_sync` tests. depth_clip_clamp has a hang when mapping buffer data asynchronously.
 - `webgpu/api/operation/shader_module`: Different shader compilation issue.
 - `webgpu/api/operation/storage_texture`: Same as `memory_sync` tests.
 - `webgpu/api/operation/vertex_state`: Same as `memory_sync` tests.

--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -162,9 +162,13 @@ export class Fixture<S extends SubcaseBatchState = SubcaseBatchState> {
     if (o instanceof GPUDevice) {
       this.objectsToCleanUp.push({
         async destroyAsync() {
+          o.queue.submit([]);
           o.destroy();
           // TODO FIXME: awaiting device.lost a second time causes promise to hang
           // await o.lost;
+          await new Promise<void>(resolve => {
+            setTimeout(resolve, 5);
+          });
         },
       });
     } else {

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -1262,9 +1262,16 @@ g.test('copy_depth_stencil')
   )
   .beforeAllSubcases(t => {
     const { format } = t.params;
-    t.selectDeviceForTextureFormatOrSkipTestCase(format);
+    if (t.params.format !== 'depth32float-stencil8') {
+      t.selectDeviceForTextureFormatOrSkipTestCase(format);
+    }
   })
   .fn(t => {
+    if (t.params.format === 'depth32float-stencil8') {
+      t.fail('depth32float-stencil8 not supported');
+      return;
+    }
+
     const {
       format,
       srcTextureSize,

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1637,9 +1637,14 @@ for all formats. We pass origin and copyExtent as [number, number, number].`
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
+
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
+    if (t.params.checkMethod === 'PartialCopyT2B') {
+      t.fail('PartialCopyT2B is flaky');
+      return;
+    }
     const {
       originValueInBlocks,
       copySizeValueInBlocks,

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -2009,70 +2009,71 @@ aspect and copyTextureToBuffer() with depth aspect.
   )
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
-    t.selectDeviceOrSkipTestCase(info.feature);
+    // t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
-    const {
-      format,
-      copyMethod,
-      aspect,
-      bytesPerRowPadding,
-      rowsPerImagePadding,
-      copyWidthInBlocks,
-      copyHeightInBlocks,
-      copyDepth,
-      mipLevel,
-    } = t.params;
-    const bytesPerBlock = depthStencilFormatAspectSize(format, aspect);
-    const rowsPerImage = copyHeightInBlocks + rowsPerImagePadding;
+    t.fail('Depth stencil tests not supported');
+    // const {
+    //   format,
+    //   copyMethod,
+    //   aspect,
+    //   bytesPerRowPadding,
+    //   rowsPerImagePadding,
+    //   copyWidthInBlocks,
+    //   copyHeightInBlocks,
+    //   copyDepth,
+    //   mipLevel,
+    // } = t.params;
+    // const bytesPerBlock = depthStencilFormatAspectSize(format, aspect);
+    // const rowsPerImage = copyHeightInBlocks + rowsPerImagePadding;
 
-    const bytesPerRowAlignment = copyMethod === 'WriteTexture' ? 1 : kBytesPerRowAlignment;
-    const bytesPerRow =
-      align(bytesPerBlock * copyWidthInBlocks, bytesPerRowAlignment) +
-      bytesPerRowPadding * bytesPerRowAlignment;
+    // const bytesPerRowAlignment = copyMethod === 'WriteTexture' ? 1 : kBytesPerRowAlignment;
+    // const bytesPerRow =
+    //   align(bytesPerBlock * copyWidthInBlocks, bytesPerRowAlignment) +
+    //   bytesPerRowPadding * bytesPerRowAlignment;
 
-    const copySize = [copyWidthInBlocks, copyHeightInBlocks, copyDepth] as const;
-    const textureSize = [
-      copyWidthInBlocks << mipLevel,
-      copyHeightInBlocks << mipLevel,
-      copyDepth,
-    ] as const;
-    if (copyMethod === 'CopyT2B') {
-      if (aspect === 'depth-only') {
-        t.DoCopyTextureToBufferWithDepthAspectTest(
-          format,
-          copySize,
-          bytesPerRowPadding,
-          rowsPerImagePadding,
-          0,
-          0,
-          mipLevel
-        );
-      } else {
-        t.DoCopyFromStencilTest(format, textureSize, bytesPerRow, rowsPerImage, 0, mipLevel);
-      }
-    } else {
-      assert(
-        aspect === 'stencil-only' && (copyMethod === 'CopyB2T' || copyMethod === 'WriteTexture')
-      );
-      const initialDataSize = dataBytesForCopyOrFail({
-        layout: { bytesPerRow, rowsPerImage },
-        format: 'stencil8',
-        copySize,
-        method: copyMethod,
-      });
+    // const copySize = [copyWidthInBlocks, copyHeightInBlocks, copyDepth] as const;
+    // const textureSize = [
+    //   copyWidthInBlocks << mipLevel,
+    //   copyHeightInBlocks << mipLevel,
+    //   copyDepth,
+    // ] as const;
+    // if (copyMethod === 'CopyT2B') {
+    //   if (aspect === 'depth-only') {
+    //     t.DoCopyTextureToBufferWithDepthAspectTest(
+    //       format,
+    //       copySize,
+    //       bytesPerRowPadding,
+    //       rowsPerImagePadding,
+    //       0,
+    //       0,
+    //       mipLevel
+    //     );
+    //   } else {
+    //     t.DoCopyFromStencilTest(format, textureSize, bytesPerRow, rowsPerImage, 0, mipLevel);
+    //   }
+    // } else {
+    //   assert(
+    //     aspect === 'stencil-only' && (copyMethod === 'CopyB2T' || copyMethod === 'WriteTexture')
+    //   );
+    //   const initialDataSize = dataBytesForCopyOrFail({
+    //     layout: { bytesPerRow, rowsPerImage },
+    //     format: 'stencil8',
+    //     copySize,
+    //     method: copyMethod,
+    //   });
 
-      t.DoUploadToStencilTest(
-        format,
-        textureSize,
-        copyMethod,
-        bytesPerRow,
-        rowsPerImage,
-        initialDataSize,
-        0,
-        mipLevel
-      );
-    }
+    //   t.DoUploadToStencilTest(
+    //     format,
+    //     textureSize,
+    //     copyMethod,
+    //     bytesPerRow,
+    //     rowsPerImage,
+    //     initialDataSize,
+    //     0,
+    //     mipLevel
+    //   );
+    // }
   });
 
 g.test('offsets_and_sizes_copy_depth_stencil')
@@ -2100,51 +2101,52 @@ copyTextureToBuffer() with depth aspect.
   )
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
-    t.selectDeviceOrSkipTestCase(info.feature);
+    // t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
-    const { format, copyMethod, aspect, offsetInBlocks, dataPaddingInBytes, copyDepth, mipLevel } =
-      t.params;
-    const bytesPerBlock = depthStencilFormatAspectSize(format, aspect);
-    const initialDataOffset = offsetInBlocks * bytesPerBlock;
-    const copySize = [3, 3, copyDepth] as const;
-    const rowsPerImage = 3;
-    const bytesPerRow = 256;
+    t.fail('depth stencil tests not supported');
+    // const { format, copyMethod, aspect, offsetInBlocks, dataPaddingInBytes, copyDepth, mipLevel } =
+    //   t.params;
+    // const bytesPerBlock = depthStencilFormatAspectSize(format, aspect);
+    // const initialDataOffset = offsetInBlocks * bytesPerBlock;
+    // const copySize = [3, 3, copyDepth] as const;
+    // const rowsPerImage = 3;
+    // const bytesPerRow = 256;
 
-    const textureSize = [copySize[0] << mipLevel, copySize[1] << mipLevel, copyDepth] as const;
-    if (copyMethod === 'CopyT2B') {
-      if (aspect === 'depth-only') {
-        t.DoCopyTextureToBufferWithDepthAspectTest(format, copySize, 0, 0, 0, 0, mipLevel);
-      } else {
-        t.DoCopyFromStencilTest(
-          format,
-          textureSize,
-          bytesPerRow,
-          rowsPerImage,
-          initialDataOffset,
-          mipLevel
-        );
-      }
-    } else {
-      assert(
-        aspect === 'stencil-only' && (copyMethod === 'CopyB2T' || copyMethod === 'WriteTexture')
-      );
-      const minDataSize = dataBytesForCopyOrFail({
-        layout: { offset: initialDataOffset, bytesPerRow, rowsPerImage },
-        format: 'stencil8',
-        copySize,
-        method: copyMethod,
-      });
-      const initialDataSize = minDataSize + dataPaddingInBytes;
-      t.DoUploadToStencilTest(
-        format,
-        textureSize,
-        copyMethod,
-        bytesPerRow,
-        rowsPerImage,
-        initialDataSize,
-        initialDataOffset,
-        mipLevel
-      );
-    }
+    // const textureSize = [copySize[0] << mipLevel, copySize[1] << mipLevel, copyDepth] as const;
+    // if (copyMethod === 'CopyT2B') {
+    //   if (aspect === 'depth-only') {
+    //     t.DoCopyTextureToBufferWithDepthAspectTest(format, copySize, 0, 0, 0, 0, mipLevel);
+    //   } else {
+    //     t.DoCopyFromStencilTest(
+    //       format,
+    //       textureSize,
+    //       bytesPerRow,
+    //       rowsPerImage,
+    //       initialDataOffset,
+    //       mipLevel
+    //     );
+    //   }
+    // } else {
+    //   assert(
+    //     aspect === 'stencil-only' && (copyMethod === 'CopyB2T' || copyMethod === 'WriteTexture')
+    //   );
+    //   const minDataSize = dataBytesForCopyOrFail({
+    //     layout: { offset: initialDataOffset, bytesPerRow, rowsPerImage },
+    //     format: 'stencil8',
+    //     copySize,
+    //     method: copyMethod,
+    //   });
+    //   const initialDataSize = minDataSize + dataPaddingInBytes;
+    //   t.DoUploadToStencilTest(
+    //     format,
+    //     textureSize,
+    //     copyMethod,
+    //     bytesPerRow,
+    //     rowsPerImage,
+    //     initialDataSize,
+    //     initialDataOffset,
+    //     mipLevel
+    //   );
+    // }
   });

--- a/src/webgpu/api/operation/memory_sync/texture/readonly_depth_stencil.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/texture/readonly_depth_stencil.spec.ts
@@ -36,291 +36,292 @@ testing while the other one is used for sampling.
     const hasDepth = formatInfo.depth !== undefined;
     const hasStencil = formatInfo.stencil !== undefined;
 
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    // t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
     t.skipIf(
       t.isCompatibility && hasDepth && hasStencil,
       'compatibility mode does not support different TEXTURE_BINDING views of the same texture in a single draw calls'
     );
   })
   .fn(t => {
-    const { format, depthReadOnly, stencilReadOnly } = t.params;
-    const formatInfo = kTextureFormatInfo[format];
-    const hasDepth = formatInfo.depth !== undefined;
-    const hasStencil = formatInfo.stencil !== undefined;
+    t.fail('readonly depth stencil crashes');
+    // const { format, depthReadOnly, stencilReadOnly } = t.params;
+    // const formatInfo = kTextureFormatInfo[format];
+    // const hasDepth = formatInfo.depth !== undefined;
+    // const hasStencil = formatInfo.stencil !== undefined;
 
-    // The 3x3 depth stencil texture used for the tests.
-    const ds = t.createTextureTracked({
-      label: 'testTexture',
-      size: [3, 3],
-      format,
-      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
-    });
+    // // The 3x3 depth stencil texture used for the tests.
+    // const ds = t.createTextureTracked({
+    //   label: 'testTexture',
+    //   size: [3, 3],
+    //   format,
+    //   usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+    // });
 
-    // Fill the texture along the X axis with stencil values 1, 2, 3 and along the Y axis depth
-    // values 0.1, 0.2, 0.3. The depth value is written using @builtin(frag_depth) while the
-    // stencil is written using stencil operation and modifying the stencilReference.
-    const initModule = t.device.createShaderModule({
-      code: `
-            @vertex fn vs(
-                @builtin(instance_index) x : u32, @builtin(vertex_index) y : u32
-            ) -> @builtin(position) vec4f {
-                let texcoord = (vec2f(f32(x), f32(y)) + vec2f(0.5)) / 3;
-                return vec4f((texcoord * 2) - vec2f(1.0), 0, 1);
-            }
-            @fragment fn fs_with_depth(@builtin(position) pos : vec4f) -> @builtin(frag_depth) f32 {
-                return (pos.y + 0.5) / 10;
-            }
-            @fragment fn fs_no_depth() {
-            }
-        `,
-    });
-    const initPipeline = t.device.createRenderPipeline({
-      layout: 'auto',
-      label: 'initPipeline',
-      vertex: { module: initModule },
-      fragment: {
-        module: initModule,
-        targets: [],
-        entryPoint: hasDepth ? 'fs_with_depth' : 'fs_no_depth',
-      },
-      depthStencil: {
-        format,
-        ...(hasDepth && {
-          depthWriteEnabled: true,
-          depthCompare: 'always',
-        }),
-        ...(hasStencil && {
-          stencilBack: { compare: 'always', passOp: 'replace' },
-          stencilFront: { compare: 'always', passOp: 'replace' },
-        }),
-      },
-      primitive: { topology: 'point-list' },
-    });
+    // // Fill the texture along the X axis with stencil values 1, 2, 3 and along the Y axis depth
+    // // values 0.1, 0.2, 0.3. The depth value is written using @builtin(frag_depth) while the
+    // // stencil is written using stencil operation and modifying the stencilReference.
+    // const initModule = t.device.createShaderModule({
+    //   code: `
+    //         @vertex fn vs(
+    //             @builtin(instance_index) x : u32, @builtin(vertex_index) y : u32
+    //         ) -> @builtin(position) vec4f {
+    //             let texcoord = (vec2f(f32(x), f32(y)) + vec2f(0.5)) / 3;
+    //             return vec4f((texcoord * 2) - vec2f(1.0), 0, 1);
+    //         }
+    //         @fragment fn fs_with_depth(@builtin(position) pos : vec4f) -> @builtin(frag_depth) f32 {
+    //             return (pos.y + 0.5) / 10;
+    //         }
+    //         @fragment fn fs_no_depth() {
+    //         }
+    //     `,
+    // });
+    // const initPipeline = t.device.createRenderPipeline({
+    //   layout: 'auto',
+    //   label: 'initPipeline',
+    //   vertex: { module: initModule },
+    //   fragment: {
+    //     module: initModule,
+    //     targets: [],
+    //     entryPoint: hasDepth ? 'fs_with_depth' : 'fs_no_depth',
+    //   },
+    //   depthStencil: {
+    //     format,
+    //     ...(hasDepth && {
+    //       depthWriteEnabled: true,
+    //       depthCompare: 'always',
+    //     }),
+    //     ...(hasStencil && {
+    //       stencilBack: { compare: 'always', passOp: 'replace' },
+    //       stencilFront: { compare: 'always', passOp: 'replace' },
+    //     }),
+    //   },
+    //   primitive: { topology: 'point-list' },
+    // });
 
-    const encoder = t.device.createCommandEncoder();
+    // const encoder = t.device.createCommandEncoder();
 
-    const initPass = encoder.beginRenderPass({
-      colorAttachments: [],
-      depthStencilAttachment: {
-        view: ds.createView(),
-        ...(hasDepth && {
-          depthLoadOp: 'clear',
-          depthStoreOp: 'store',
-          depthClearValue: 0,
-        }),
-        ...(hasStencil && {
-          stencilLoadOp: 'clear',
-          stencilStoreOp: 'store',
-          stencilClearValue: 0,
-        }),
-      },
-    });
-    initPass.setPipeline(initPipeline);
-    for (let i = 0; i < 3; i++) {
-      initPass.setStencilReference(i + 1);
-      // Draw 3 points (Y = 0, 1, 2) at X = instance_index = i.
-      initPass.draw(3, 1, 0, i);
-    }
-    initPass.end();
+    // const initPass = encoder.beginRenderPass({
+    //   colorAttachments: [],
+    //   depthStencilAttachment: {
+    //     view: ds.createView(),
+    //     ...(hasDepth && {
+    //       depthLoadOp: 'clear',
+    //       depthStoreOp: 'store',
+    //       depthClearValue: 0,
+    //     }),
+    //     ...(hasStencil && {
+    //       stencilLoadOp: 'clear',
+    //       stencilStoreOp: 'store',
+    //       stencilClearValue: 0,
+    //     }),
+    //   },
+    // });
+    // initPass.setPipeline(initPipeline);
+    // for (let i = 0; i < 3; i++) {
+    //   initPass.setStencilReference(i + 1);
+    //   // Draw 3 points (Y = 0, 1, 2) at X = instance_index = i.
+    //   initPass.draw(3, 1, 0, i);
+    // }
+    // initPass.end();
 
-    // Perform the actual test:
-    //   - The shader outputs depth 0.15 and stencil 2 (via stencilReference).
-    //   - Test that the fragdepth / stencilref must be <= to what's in the depth-stencil attachment.
-    //      -> Fragments that have depth 0.1 or stencil 1 are tested out.
-    //   - Test that sampling the depth / stencil (when possible) is <= 0.2 for depth, <= 2 for stencil
-    //      -> Fragments that have depth 0.3 or stencil 3 are discarded if that aspect is readonly.
-    //   - Write the depth / increment the stencil if the aspect is not readonly.
-    //      -> After the test, fragments that passed will have non-readonly aspects updated.
-    const kFragDepth = 0.15;
-    const kStencilRef = 2;
-    const testAndCheckModule = t.device.createShaderModule({
-      code: `
-          @group(0) @binding(0) var depthTex : texture_2d<f32>;
-          @group(0) @binding(1) var stencilTex : texture_2d<u32>;
+    // // Perform the actual test:
+    // //   - The shader outputs depth 0.15 and stencil 2 (via stencilReference).
+    // //   - Test that the fragdepth / stencilref must be <= to what's in the depth-stencil attachment.
+    // //      -> Fragments that have depth 0.1 or stencil 1 are tested out.
+    // //   - Test that sampling the depth / stencil (when possible) is <= 0.2 for depth, <= 2 for stencil
+    // //      -> Fragments that have depth 0.3 or stencil 3 are discarded if that aspect is readonly.
+    // //   - Write the depth / increment the stencil if the aspect is not readonly.
+    // //      -> After the test, fragments that passed will have non-readonly aspects updated.
+    // const kFragDepth = 0.15;
+    // const kStencilRef = 2;
+    // const testAndCheckModule = t.device.createShaderModule({
+    //   code: `
+    //       @group(0) @binding(0) var depthTex : texture_2d<f32>;
+    //       @group(0) @binding(1) var stencilTex : texture_2d<u32>;
 
-          @vertex fn full_quad_vs(@builtin(vertex_index) id : u32) -> @builtin(position) vec4f {
-            let pos = array(vec2f(-3, -1), vec2(3, -1), vec2(0, 2));
-            return vec4f(pos[id], ${kFragDepth}, 1.0);
-          }
+    //       @vertex fn full_quad_vs(@builtin(vertex_index) id : u32) -> @builtin(position) vec4f {
+    //         let pos = array(vec2f(-3, -1), vec2(3, -1), vec2(0, 2));
+    //         return vec4f(pos[id], ${kFragDepth}, 1.0);
+    //       }
 
-          @fragment fn test_texture(@builtin(position) pos : vec4f) {
-            let texel = vec2u(floor(pos.xy));
-            if ${!!stencilReadOnly} && textureLoad(stencilTex, texel, 0).r > 2 {
-                discard;
-            }
-            if ${!!depthReadOnly} && textureLoad(depthTex, texel, 0).r > 0.21 {
-                discard;
-            }
-          }
+    //       @fragment fn test_texture(@builtin(position) pos : vec4f) {
+    //         let texel = vec2u(floor(pos.xy));
+    //         if ${!!stencilReadOnly} && textureLoad(stencilTex, texel, 0).r > 2 {
+    //             discard;
+    //         }
+    //         if ${!!depthReadOnly} && textureLoad(depthTex, texel, 0).r > 0.21 {
+    //             discard;
+    //         }
+    //       }
 
-          @fragment fn check_texture(@builtin(position) pos : vec4f) -> @location(0) u32 {
-            let texel = vec2u(floor(pos.xy));
+    //       @fragment fn check_texture(@builtin(position) pos : vec4f) -> @location(0) u32 {
+    //         let texel = vec2u(floor(pos.xy));
 
-            // The current values in the framebuffer.
-            let initStencil = texel.x + 1;
-            let initDepth = f32(texel.y + 1) / 10.0;
+    //         // The current values in the framebuffer.
+    //         let initStencil = texel.x + 1;
+    //         let initDepth = f32(texel.y + 1) / 10.0;
 
-            // Expected results of the test_texture step.
-            let stencilTestPasses = !${hasStencil} || ${kStencilRef} <= initStencil;
-            let depthTestPasses = !${hasDepth} || ${kFragDepth} <= initDepth;
-            let fsDiscards = (${!!stencilReadOnly} && initStencil > 2) ||
-                             (${!!depthReadOnly} && initDepth > 0.21);
+    //         // Expected results of the test_texture step.
+    //         let stencilTestPasses = !${hasStencil} || ${kStencilRef} <= initStencil;
+    //         let depthTestPasses = !${hasDepth} || ${kFragDepth} <= initDepth;
+    //         let fsDiscards = (${!!stencilReadOnly} && initStencil > 2) ||
+    //                          (${!!depthReadOnly} && initDepth > 0.21);
 
-            // Compute the values that should be in the framebuffer.
-            var stencil = initStencil;
-            var depth = initDepth;
+    //         // Compute the values that should be in the framebuffer.
+    //         var stencil = initStencil;
+    //         var depth = initDepth;
 
-            // When the fragments aren't discarded, fragment output operations happen.
-            if depthTestPasses && stencilTestPasses && !fsDiscards {
-                if ${!stencilReadOnly} {
-                    stencil += 1;
-                }
-                if ${!depthReadOnly} {
-                    depth = ${kFragDepth};
-                }
-            }
+    //         // When the fragments aren't discarded, fragment output operations happen.
+    //         if depthTestPasses && stencilTestPasses && !fsDiscards {
+    //             if ${!stencilReadOnly} {
+    //                 stencil += 1;
+    //             }
+    //             if ${!depthReadOnly} {
+    //                 depth = ${kFragDepth};
+    //             }
+    //         }
 
-            if ${hasStencil} && textureLoad(stencilTex, texel, 0).r != stencil {
-                return 0;
-            }
-            if ${hasDepth} && abs(textureLoad(depthTex, texel, 0).r - depth) > 0.01 {
-                return 0;
-            }
-            return 1;
-          }
-    `,
-    });
-    const testPipeline = t.device.createRenderPipeline({
-      label: 'testPipeline',
-      layout: 'auto',
-      vertex: { module: testAndCheckModule },
-      fragment: { module: testAndCheckModule, entryPoint: 'test_texture', targets: [] },
-      depthStencil: {
-        format,
-        ...(hasDepth && {
-          depthCompare: 'less-equal',
-          depthWriteEnabled: !depthReadOnly,
-        }),
-        ...(hasStencil && {
-          stencilBack: {
-            compare: 'less-equal',
-            passOp: stencilReadOnly ? 'keep' : 'increment-clamp',
-          },
-          stencilFront: {
-            compare: 'less-equal',
-            passOp: stencilReadOnly ? 'keep' : 'increment-clamp',
-          },
-        }),
-      },
-      primitive: { topology: 'triangle-list' },
-    });
+    //         if ${hasStencil} && textureLoad(stencilTex, texel, 0).r != stencil {
+    //             return 0;
+    //         }
+    //         if ${hasDepth} && abs(textureLoad(depthTex, texel, 0).r - depth) > 0.01 {
+    //             return 0;
+    //         }
+    //         return 1;
+    //       }
+    // `,
+    // });
+    // const testPipeline = t.device.createRenderPipeline({
+    //   label: 'testPipeline',
+    //   layout: 'auto',
+    //   vertex: { module: testAndCheckModule },
+    //   fragment: { module: testAndCheckModule, entryPoint: 'test_texture', targets: [] },
+    //   depthStencil: {
+    //     format,
+    //     ...(hasDepth && {
+    //       depthCompare: 'less-equal',
+    //       depthWriteEnabled: !depthReadOnly,
+    //     }),
+    //     ...(hasStencil && {
+    //       stencilBack: {
+    //         compare: 'less-equal',
+    //         passOp: stencilReadOnly ? 'keep' : 'increment-clamp',
+    //       },
+    //       stencilFront: {
+    //         compare: 'less-equal',
+    //         passOp: stencilReadOnly ? 'keep' : 'increment-clamp',
+    //       },
+    //     }),
+    //   },
+    //   primitive: { topology: 'triangle-list' },
+    // });
 
-    // Make fake stencil or depth textures to put in the bindgroup if the aspect is not readonly.
-    const fakeStencil = t.createTextureTracked({
-      label: 'fakeStencil',
-      format: 'r32uint',
-      size: [1, 1],
-      usage: GPUTextureUsage.TEXTURE_BINDING,
-    });
-    const fakeDepth = t.createTextureTracked({
-      label: 'fakeDepth',
-      format: 'r32float',
-      size: [1, 1],
-      usage: GPUTextureUsage.TEXTURE_BINDING,
-    });
-    const stencilView = stencilReadOnly
-      ? ds.createView({ aspect: 'stencil-only' })
-      : fakeStencil.createView();
-    const depthView = depthReadOnly
-      ? ds.createView({ aspect: 'depth-only' })
-      : fakeDepth.createView();
-    const testBindGroup = t.device.createBindGroup({
-      layout: testPipeline.getBindGroupLayout(0),
-      entries: [
-        { binding: 0, resource: depthView },
-        { binding: 1, resource: stencilView },
-      ],
-    });
+    // // Make fake stencil or depth textures to put in the bindgroup if the aspect is not readonly.
+    // const fakeStencil = t.createTextureTracked({
+    //   label: 'fakeStencil',
+    //   format: 'r32uint',
+    //   size: [1, 1],
+    //   usage: GPUTextureUsage.TEXTURE_BINDING,
+    // });
+    // const fakeDepth = t.createTextureTracked({
+    //   label: 'fakeDepth',
+    //   format: 'r32float',
+    //   size: [1, 1],
+    //   usage: GPUTextureUsage.TEXTURE_BINDING,
+    // });
+    // const stencilView = stencilReadOnly
+    //   ? ds.createView({ aspect: 'stencil-only' })
+    //   : fakeStencil.createView();
+    // const depthView = depthReadOnly
+    //   ? ds.createView({ aspect: 'depth-only' })
+    //   : fakeDepth.createView();
+    // const testBindGroup = t.device.createBindGroup({
+    //   layout: testPipeline.getBindGroupLayout(0),
+    //   entries: [
+    //     { binding: 0, resource: depthView },
+    //     { binding: 1, resource: stencilView },
+    //   ],
+    // });
 
-    // Run the test.
-    const testPass = encoder.beginRenderPass({
-      colorAttachments: [],
-      depthStencilAttachment: {
-        view: ds.createView(),
-        ...(hasDepth &&
-          (depthReadOnly
-            ? { depthReadOnly: true }
-            : {
-                depthLoadOp: 'load',
-                depthStoreOp: 'store',
-              })),
-        ...(hasStencil &&
-          (stencilReadOnly
-            ? { stencilReadOnly: true }
-            : {
-                stencilLoadOp: 'load',
-                stencilStoreOp: 'store',
-              })),
-      },
-    });
-    testPass.setPipeline(testPipeline);
-    testPass.setStencilReference(kStencilRef);
-    testPass.setBindGroup(0, testBindGroup);
-    testPass.draw(3);
-    testPass.end();
+    // // Run the test.
+    // const testPass = encoder.beginRenderPass({
+    //   colorAttachments: [],
+    //   depthStencilAttachment: {
+    //     view: ds.createView(),
+    //     ...(hasDepth &&
+    //       (depthReadOnly
+    //         ? { depthReadOnly: true }
+    //         : {
+    //             depthLoadOp: 'load',
+    //             depthStoreOp: 'store',
+    //           })),
+    //     ...(hasStencil &&
+    //       (stencilReadOnly
+    //         ? { stencilReadOnly: true }
+    //         : {
+    //             stencilLoadOp: 'load',
+    //             stencilStoreOp: 'store',
+    //           })),
+    //   },
+    // });
+    // testPass.setPipeline(testPipeline);
+    // testPass.setStencilReference(kStencilRef);
+    // testPass.setBindGroup(0, testBindGroup);
+    // testPass.draw(3);
+    // testPass.end();
 
-    // Check that the contents of the textures are what we expect. See the shader module for the
-    // computation of what's expected, it writes a 1 on success, 0 otherwise.
-    const checkPipeline = t.device.createRenderPipeline({
-      label: 'checkPipeline',
-      layout: 'auto',
-      vertex: { module: testAndCheckModule },
-      fragment: {
-        module: testAndCheckModule,
-        entryPoint: 'check_texture',
-        targets: [{ format: 'r32uint' }],
-      },
-      primitive: { topology: 'triangle-list' },
-    });
-    const checkBindGroup = t.device.createBindGroup({
-      layout: checkPipeline.getBindGroupLayout(0),
-      entries: [
-        {
-          binding: 0,
-          resource: hasDepth ? ds.createView({ aspect: 'depth-only' }) : fakeDepth.createView(),
-        },
-        {
-          binding: 1,
-          resource: hasStencil
-            ? ds.createView({ aspect: 'stencil-only' })
-            : fakeStencil.createView(),
-        },
-      ],
-    });
+    // // Check that the contents of the textures are what we expect. See the shader module for the
+    // // computation of what's expected, it writes a 1 on success, 0 otherwise.
+    // const checkPipeline = t.device.createRenderPipeline({
+    //   label: 'checkPipeline',
+    //   layout: 'auto',
+    //   vertex: { module: testAndCheckModule },
+    //   fragment: {
+    //     module: testAndCheckModule,
+    //     entryPoint: 'check_texture',
+    //     targets: [{ format: 'r32uint' }],
+    //   },
+    //   primitive: { topology: 'triangle-list' },
+    // });
+    // const checkBindGroup = t.device.createBindGroup({
+    //   layout: checkPipeline.getBindGroupLayout(0),
+    //   entries: [
+    //     {
+    //       binding: 0,
+    //       resource: hasDepth ? ds.createView({ aspect: 'depth-only' }) : fakeDepth.createView(),
+    //     },
+    //     {
+    //       binding: 1,
+    //       resource: hasStencil
+    //         ? ds.createView({ aspect: 'stencil-only' })
+    //         : fakeStencil.createView(),
+    //     },
+    //   ],
+    // });
 
-    const resultTexture = t.createTextureTracked({
-      label: 'resultTexture',
-      format: 'r32uint',
-      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
-      size: [3, 3],
-    });
-    const checkPass = encoder.beginRenderPass({
-      colorAttachments: [
-        {
-          view: resultTexture.createView(),
-          loadOp: 'clear',
-          clearValue: [0, 0, 0, 0],
-          storeOp: 'store',
-        },
-      ],
-    });
-    checkPass.setPipeline(checkPipeline);
-    checkPass.setBindGroup(0, checkBindGroup);
-    checkPass.draw(3);
-    checkPass.end();
+    // const resultTexture = t.createTextureTracked({
+    //   label: 'resultTexture',
+    //   format: 'r32uint',
+    //   usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    //   size: [3, 3],
+    // });
+    // const checkPass = encoder.beginRenderPass({
+    //   colorAttachments: [
+    //     {
+    //       view: resultTexture.createView(),
+    //       loadOp: 'clear',
+    //       clearValue: [0, 0, 0, 0],
+    //       storeOp: 'store',
+    //     },
+    //   ],
+    // });
+    // checkPass.setPipeline(checkPipeline);
+    // checkPass.setBindGroup(0, checkBindGroup);
+    // checkPass.draw(3);
+    // checkPass.end();
 
-    t.queue.submit([encoder.finish()]);
+    // t.queue.submit([encoder.finish()]);
 
-    // The check texture should be full of success (a.k.a. 1)!
-    t.expectSingleColor(resultTexture, resultTexture.format, { size: [3, 3, 1], exp: { R: 1 } });
+    // // The check texture should be full of success (a.k.a. 1)!
+    // t.expectSingleColor(resultTexture, resultTexture.format, { size: [3, 3, 1], exp: { R: 1 } });
   });

--- a/src/webgpu/api/operation/render_pass/clear_value.spec.ts
+++ b/src/webgpu/api/operation/render_pass/clear_value.spec.ts
@@ -56,9 +56,16 @@ g.test('stencil_clear_value')
   .beforeAllSubcases(t => {
     const { stencilFormat } = t.params;
     const info = kTextureFormatInfo[stencilFormat];
-    t.selectDeviceOrSkipTestCase(info.feature);
+    if (stencilFormat !== 'depth32float-stencil8') {
+      t.selectDeviceOrSkipTestCase(info.feature);
+    }
   })
   .fn(t => {
+    if (t.params.stencilFormat === 'depth32float-stencil8') {
+      t.fail('stencil format not supported');
+      return;
+    }
+
     const { stencilFormat, stencilClearValue, applyStencilClearValueAsStencilReferenceValue } =
       t.params;
 

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -295,9 +295,7 @@ g.test('depth_compare_func')
     u
       .combine(
         'format',
-        kDepthStencilFormats.filter(
-          format => kTextureFormatInfo[format].depth && format !== 'depth32float-stencil8'
-        )
+        kDepthStencilFormats.filter(format => kTextureFormatInfo[format].depth)
       )
       .combineWithParams([
         { depthCompare: 'never', depthClearValue: 1.0, _expected: backgroundColor },
@@ -339,9 +337,15 @@ g.test('depth_compare_func')
       ] as const)
   )
   .beforeAllSubcases(t => {
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    if (t.params.format !== 'depth32float-stencil8') {
+      t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    }
   })
   .fn(t => {
+    if (t.params.format === 'depth32float-stencil8') {
+      t.fail('Unsupported format depth32float-stencil8');
+      return;
+    }
     const { depthCompare, depthClearValue, _expected, format } = t.params;
 
     const colorAttachmentFormat = 'rgba8unorm';

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -295,7 +295,9 @@ g.test('depth_compare_func')
     u
       .combine(
         'format',
-        kDepthStencilFormats.filter(format => kTextureFormatInfo[format].depth)
+        kDepthStencilFormats.filter(
+          format => kTextureFormatInfo[format].depth && format !== 'depth32float-stencil8'
+        )
       )
       .combineWithParams([
         { depthCompare: 'never', depthClearValue: 1.0, _expected: backgroundColor },

--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -325,13 +325,15 @@ have unexpected values then get drawn to the color buffer, which is later checke
       { leftHeader: 'expected ==', getValueForCell: _index => kCheckPassedValue },
     ];
     if (dsActual && dsExpected && format === 'depth32float') {
-      await Promise.all([dsActual.mapAsync(GPUMapMode.READ), dsExpected.mapAsync(GPUMapMode.READ)]);
-      const act = new Float32Array(dsActual.getMappedRange());
-      const exp = new Float32Array(dsExpected.getMappedRange());
-      predicatePrinter.push(
-        { leftHeader: 'act ==', getValueForCell: index => act[index].toFixed(2) },
-        { leftHeader: 'exp ==', getValueForCell: index => exp[index].toFixed(2) }
-      );
+      t.fail('depth32float unsupported');
+      return;
+      // await Promise.all([dsActual.mapAsync(GPUMapMode.READ), dsExpected.mapAsync(GPUMapMode.READ)]);
+      // const act = new Float32Array(dsActual.getMappedRange());
+      // const exp = new Float32Array(dsExpected.getMappedRange());
+      // predicatePrinter.push(
+      //   { leftHeader: 'act ==', getValueForCell: index => act[index].toFixed(2) },
+      //   { leftHeader: 'exp ==', getValueForCell: index => exp[index].toFixed(2) }
+      // );
     }
     t.expectGPUBufferValuesPassCheck(
       checkBuffer,

--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -45,304 +45,305 @@ have unexpected values then get drawn to the color buffer, which is later checke
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
 
-    t.selectDeviceOrSkipTestCase([
-      t.params.unclippedDepth ? 'depth-clip-control' : undefined,
-      info.feature,
-    ]);
+    // t.selectDeviceOrSkipTestCase([
+    //   t.params.unclippedDepth ? 'depth-clip-control' : undefined,
+    //   info.feature,
+    // ]);
   })
   .fn(async t => {
-    const { format, unclippedDepth, writeDepth, multisampled } = t.params;
-    const info = kTextureFormatInfo[format];
-    assert(!!info.depth);
+    t.fail('depth_clip_clamp not supported');
+    // const { format, unclippedDepth, writeDepth, multisampled } = t.params;
+    // const info = kTextureFormatInfo[format];
+    // assert(!!info.depth);
 
-    /** Number of depth values to test for both vertex output and frag_depth output. */
-    const kNumDepthValues = 8;
-    /** Test every combination of vertex output and frag_depth output. */
-    const kNumTestPoints = kNumDepthValues * kNumDepthValues;
-    const kViewportMinDepth = 0.25;
-    const kViewportMaxDepth = 0.75;
+    // /** Number of depth values to test for both vertex output and frag_depth output. */
+    // const kNumDepthValues = 8;
+    // /** Test every combination of vertex output and frag_depth output. */
+    // const kNumTestPoints = kNumDepthValues * kNumDepthValues;
+    // const kViewportMinDepth = 0.25;
+    // const kViewportMaxDepth = 0.75;
 
-    const shaderSource = `
-      // Test depths, with viewport range corresponding to [0,1].
-      var<private> kDepths: array<f32, ${kNumDepthValues}> = array<f32, ${kNumDepthValues}>(
-          -1.0, -0.5, 0.0, 0.25, 0.75, 1.0, 1.5, 2.0);
+    // const shaderSource = `
+    //   // Test depths, with viewport range corresponding to [0,1].
+    //   var<private> kDepths: array<f32, ${kNumDepthValues}> = array<f32, ${kNumDepthValues}>(
+    //       -1.0, -0.5, 0.0, 0.25, 0.75, 1.0, 1.5, 2.0);
 
-      const vpMin: f32 = ${kViewportMinDepth};
-      const vpMax: f32 = ${kViewportMaxDepth};
+    //   const vpMin: f32 = ${kViewportMinDepth};
+    //   const vpMax: f32 = ${kViewportMaxDepth};
 
-      // Draw the points in a straight horizontal row, one per pixel.
-      fn vertexX(idx: u32) -> f32 {
-        return (f32(idx) + 0.5) * 2.0 / ${kNumTestPoints}.0 - 1.0;
-      }
+    //   // Draw the points in a straight horizontal row, one per pixel.
+    //   fn vertexX(idx: u32) -> f32 {
+    //     return (f32(idx) + 0.5) * 2.0 / ${kNumTestPoints}.0 - 1.0;
+    //   }
 
-      // Test vertex shader's position.z output.
-      // Here, the viewport range corresponds to position.z in [0,1].
-      fn vertexZ(idx: u32) -> f32 {
-        return kDepths[idx / ${kNumDepthValues}u];
-      }
+    //   // Test vertex shader's position.z output.
+    //   // Here, the viewport range corresponds to position.z in [0,1].
+    //   fn vertexZ(idx: u32) -> f32 {
+    //     return kDepths[idx / ${kNumDepthValues}u];
+    //   }
 
-      // Test fragment shader's expected position.z input.
-      // Here, the viewport range corresponds to position.z in [vpMin,vpMax], but
-      // unclipped values extend beyond that range.
-      fn expectedFragPosZ(idx: u32) -> f32 {
-        return vpMin + vertexZ(idx) * (vpMax - vpMin);
-      }
+    //   // Test fragment shader's expected position.z input.
+    //   // Here, the viewport range corresponds to position.z in [vpMin,vpMax], but
+    //   // unclipped values extend beyond that range.
+    //   fn expectedFragPosZ(idx: u32) -> f32 {
+    //     return vpMin + vertexZ(idx) * (vpMax - vpMin);
+    //   }
 
-      //////// "Test" entry points
+    //   //////// "Test" entry points
 
-      struct VFTest {
-        @builtin(position) pos: vec4<f32>,
-        @location(0) @interpolate(flat, either) vertexIndex: u32,
-      };
+    //   struct VFTest {
+    //     @builtin(position) pos: vec4<f32>,
+    //     @location(0) @interpolate(flat, either) vertexIndex: u32,
+    //   };
 
-      @vertex
-      fn vtest(@builtin(vertex_index) idx: u32) -> VFTest {
-        var vf: VFTest;
-        vf.pos = vec4<f32>(vertexX(idx), 0.0, vertexZ(idx), 1.0);
-        vf.vertexIndex = idx;
-        return vf;
-      }
+    //   @vertex
+    //   fn vtest(@builtin(vertex_index) idx: u32) -> VFTest {
+    //     var vf: VFTest;
+    //     vf.pos = vec4<f32>(vertexX(idx), 0.0, vertexZ(idx), 1.0);
+    //     vf.vertexIndex = idx;
+    //     return vf;
+    //   }
 
-      struct Output {
-        // Each fragment (that didn't get clipped) writes into one element of this output.
-        // (Anything that doesn't get written is already zero.)
-        fragInputZDiff: array<f32, ${kNumTestPoints}>
-      };
-      @group(0) @binding(0) var <storage, read_write> output: Output;
+    //   struct Output {
+    //     // Each fragment (that didn't get clipped) writes into one element of this output.
+    //     // (Anything that doesn't get written is already zero.)
+    //     fragInputZDiff: array<f32, ${kNumTestPoints}>
+    //   };
+    //   @group(0) @binding(0) var <storage, read_write> output: Output;
 
-      fn checkZ(vf: VFTest) {
-        output.fragInputZDiff[vf.vertexIndex] = vf.pos.z - expectedFragPosZ(vf.vertexIndex);
-      }
+    //   fn checkZ(vf: VFTest) {
+    //     output.fragInputZDiff[vf.vertexIndex] = vf.pos.z - expectedFragPosZ(vf.vertexIndex);
+    //   }
 
-      @fragment
-      fn ftest_WriteDepth(vf: VFTest) -> @builtin(frag_depth) f32 {
-        checkZ(vf);
-        return kDepths[vf.vertexIndex % ${kNumDepthValues}u];
-      }
+    //   @fragment
+    //   fn ftest_WriteDepth(vf: VFTest) -> @builtin(frag_depth) f32 {
+    //     checkZ(vf);
+    //     return kDepths[vf.vertexIndex % ${kNumDepthValues}u];
+    //   }
 
-      @fragment
-      fn ftest_NoWriteDepth(vf: VFTest) {
-        checkZ(vf);
-      }
+    //   @fragment
+    //   fn ftest_NoWriteDepth(vf: VFTest) {
+    //     checkZ(vf);
+    //   }
 
-      //////// "Check" entry points
+    //   //////// "Check" entry points
 
-      struct VFCheck {
-        @builtin(position) pos: vec4<f32>,
-        @location(0) @interpolate(flat, either) vertexIndex: u32,
-      };
+    //   struct VFCheck {
+    //     @builtin(position) pos: vec4<f32>,
+    //     @location(0) @interpolate(flat, either) vertexIndex: u32,
+    //   };
 
-      @vertex
-      fn vcheck(@builtin(vertex_index) idx: u32) -> VFCheck {
-        var vf: VFCheck;
-        // Depth=0.5 because we want to render every point, not get clipped.
-        vf.pos = vec4<f32>(vertexX(idx), 0.0, 0.5, 1.0);
-        vf.vertexIndex = idx;
-        return vf;
-      }
+    //   @vertex
+    //   fn vcheck(@builtin(vertex_index) idx: u32) -> VFCheck {
+    //     var vf: VFCheck;
+    //     // Depth=0.5 because we want to render every point, not get clipped.
+    //     vf.pos = vec4<f32>(vertexX(idx), 0.0, 0.5, 1.0);
+    //     vf.vertexIndex = idx;
+    //     return vf;
+    //   }
 
-      struct FCheck {
-        @builtin(frag_depth) depth: f32,
-        @location(0) color: f32,
-      };
+    //   struct FCheck {
+    //     @builtin(frag_depth) depth: f32,
+    //     @location(0) color: f32,
+    //   };
 
-      @fragment
-      fn fcheck(vf: VFCheck) -> FCheck {
-        let vertZ = vertexZ(vf.vertexIndex);
-        let outOfRange = vertZ < 0.0 || vertZ > 1.0;
-        let expFragPosZ = expectedFragPosZ(vf.vertexIndex);
+    //   @fragment
+    //   fn fcheck(vf: VFCheck) -> FCheck {
+    //     let vertZ = vertexZ(vf.vertexIndex);
+    //     let outOfRange = vertZ < 0.0 || vertZ > 1.0;
+    //     let expFragPosZ = expectedFragPosZ(vf.vertexIndex);
 
-        let writtenDepth = kDepths[vf.vertexIndex % ${kNumDepthValues}u];
+    //     let writtenDepth = kDepths[vf.vertexIndex % ${kNumDepthValues}u];
 
-        let expectedDepthWriteInput = ${writeDepth ? 'writtenDepth' : 'expFragPosZ'};
-        var expectedDepthBufferValue = clamp(expectedDepthWriteInput, vpMin, vpMax);
-        if (${!unclippedDepth} && outOfRange) {
-          // Test fragment should have been clipped; expect the depth attachment to
-          // have its clear value (0.5).
-          expectedDepthBufferValue = 0.5;
-        }
+    //     let expectedDepthWriteInput = ${writeDepth ? 'writtenDepth' : 'expFragPosZ'};
+    //     var expectedDepthBufferValue = clamp(expectedDepthWriteInput, vpMin, vpMax);
+    //     if (${!unclippedDepth} && outOfRange) {
+    //       // Test fragment should have been clipped; expect the depth attachment to
+    //       // have its clear value (0.5).
+    //       expectedDepthBufferValue = 0.5;
+    //     }
 
-        var f: FCheck;
-        f.depth = expectedDepthBufferValue;
-        f.color = 1.0; // Color written if the resulting depth is unexpected.
-        return f;
-      }
-    `;
-    const module = t.device.createShaderModule({ code: shaderSource });
+    //     var f: FCheck;
+    //     f.depth = expectedDepthBufferValue;
+    //     f.color = 1.0; // Color written if the resulting depth is unexpected.
+    //     return f;
+    //   }
+    // `;
+    // const module = t.device.createShaderModule({ code: shaderSource });
 
-    // Draw points at different vertex depths and fragment depths into the depth attachment,
-    // with a viewport of [0.25,0.75].
-    const testPipeline = t.device.createRenderPipeline({
-      layout: 'auto',
-      vertex: { module, entryPoint: 'vtest' },
-      primitive: {
-        topology: 'point-list',
-        unclippedDepth,
-      },
-      depthStencil: { format, depthWriteEnabled: true, depthCompare: 'always' },
-      multisample: multisampled ? { count: 4 } : undefined,
-      fragment: {
-        module,
-        entryPoint: writeDepth ? 'ftest_WriteDepth' : 'ftest_NoWriteDepth',
-        targets: [],
-      },
-    });
+    // // Draw points at different vertex depths and fragment depths into the depth attachment,
+    // // with a viewport of [0.25,0.75].
+    // const testPipeline = t.device.createRenderPipeline({
+    //   layout: 'auto',
+    //   vertex: { module, entryPoint: 'vtest' },
+    //   primitive: {
+    //     topology: 'point-list',
+    //     unclippedDepth,
+    //   },
+    //   depthStencil: { format, depthWriteEnabled: true, depthCompare: 'always' },
+    //   multisample: multisampled ? { count: 4 } : undefined,
+    //   fragment: {
+    //     module,
+    //     entryPoint: writeDepth ? 'ftest_WriteDepth' : 'ftest_NoWriteDepth',
+    //     targets: [],
+    //   },
+    // });
 
-    // Use depth comparison to check that the depth attachment now has the expected values.
-    const checkPipeline = t.device.createRenderPipeline({
-      layout: 'auto',
-      vertex: { module, entryPoint: 'vcheck' },
-      primitive: { topology: 'point-list' },
-      depthStencil: {
-        format,
-        // NOTE: This check is probably very susceptible to floating point error. If it fails, maybe
-        // replace it with two checks (less + greater) with an epsilon applied in the check shader?
-        depthCompare: 'not-equal', // Expect every depth value to be exactly equal.
-        depthWriteEnabled: true, // If the check failed, overwrite with the expected result.
-      },
-      multisample: multisampled ? { count: 4 } : undefined,
-      fragment: { module, entryPoint: 'fcheck', targets: [{ format: 'r8unorm' }] },
-    });
+    // // Use depth comparison to check that the depth attachment now has the expected values.
+    // const checkPipeline = t.device.createRenderPipeline({
+    //   layout: 'auto',
+    //   vertex: { module, entryPoint: 'vcheck' },
+    //   primitive: { topology: 'point-list' },
+    //   depthStencil: {
+    //     format,
+    //     // NOTE: This check is probably very susceptible to floating point error. If it fails, maybe
+    //     // replace it with two checks (less + greater) with an epsilon applied in the check shader?
+    //     depthCompare: 'not-equal', // Expect every depth value to be exactly equal.
+    //     depthWriteEnabled: true, // If the check failed, overwrite with the expected result.
+    //   },
+    //   multisample: multisampled ? { count: 4 } : undefined,
+    //   fragment: { module, entryPoint: 'fcheck', targets: [{ format: 'r8unorm' }] },
+    // });
 
-    const dsTexture = t.createTextureTracked({
-      format,
-      size: [kNumTestPoints],
-      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
-      sampleCount: multisampled ? 4 : 1,
-    });
-    const dsTextureView = dsTexture.createView();
+    // const dsTexture = t.createTextureTracked({
+    //   format,
+    //   size: [kNumTestPoints],
+    //   usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    //   sampleCount: multisampled ? 4 : 1,
+    // });
+    // const dsTextureView = dsTexture.createView();
 
-    const checkTextureDesc = {
-      format: 'r8unorm' as const,
-      size: [kNumTestPoints],
-      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
-    };
-    const checkTexture = t.createTextureTracked(checkTextureDesc);
-    const checkTextureView = checkTexture.createView();
-    const checkTextureMSView = multisampled
-      ? t.createTextureTracked({ ...checkTextureDesc, sampleCount: 4 }).createView()
-      : undefined;
+    // const checkTextureDesc = {
+    //   format: 'r8unorm' as const,
+    //   size: [kNumTestPoints],
+    //   usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    // };
+    // const checkTexture = t.createTextureTracked(checkTextureDesc);
+    // const checkTextureView = checkTexture.createView();
+    // const checkTextureMSView = multisampled
+    //   ? t.createTextureTracked({ ...checkTextureDesc, sampleCount: 4 }).createView()
+    //   : undefined;
 
-    const dsActual =
-      !multisampled && info.depth.bytes
-        ? t.createBufferTracked({
-            size: kNumTestPoints * info.depth.bytes,
-            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
-          })
-        : undefined;
-    const dsExpected =
-      !multisampled && info.depth.bytes
-        ? t.createBufferTracked({
-            size: kNumTestPoints * info.depth.bytes,
-            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
-          })
-        : undefined;
-    const checkBuffer = t.createBufferTracked({
-      size: kNumTestPoints,
-      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
-    });
+    // const dsActual =
+    //   !multisampled && info.depth.bytes
+    //     ? t.createBufferTracked({
+    //         size: kNumTestPoints * info.depth.bytes,
+    //         usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+    //       })
+    //     : undefined;
+    // const dsExpected =
+    //   !multisampled && info.depth.bytes
+    //     ? t.createBufferTracked({
+    //         size: kNumTestPoints * info.depth.bytes,
+    //         usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+    //       })
+    //     : undefined;
+    // const checkBuffer = t.createBufferTracked({
+    //   size: kNumTestPoints,
+    //   usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+    // });
 
-    const fragInputZFailedBuffer = t.createBufferTracked({
-      size: 4 * kNumTestPoints,
-      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
-    });
-    const testBindGroup = t.device.createBindGroup({
-      layout: testPipeline.getBindGroupLayout(0),
-      entries: [{ binding: 0, resource: { buffer: fragInputZFailedBuffer } }],
-    });
+    // const fragInputZFailedBuffer = t.createBufferTracked({
+    //   size: 4 * kNumTestPoints,
+    //   usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    // });
+    // const testBindGroup = t.device.createBindGroup({
+    //   layout: testPipeline.getBindGroupLayout(0),
+    //   entries: [{ binding: 0, resource: { buffer: fragInputZFailedBuffer } }],
+    // });
 
-    const enc = t.device.createCommandEncoder();
-    {
-      const pass = enc.beginRenderPass({
-        colorAttachments: [],
-        depthStencilAttachment: {
-          view: dsTextureView,
-          depthClearValue: 0.5, // Will see this depth value if the fragment was clipped.
-          depthLoadOp: 'clear',
-          depthStoreOp: 'store',
-          stencilClearValue: info.stencil ? 0 : undefined,
-          stencilLoadOp: info.stencil ? 'clear' : undefined,
-          stencilStoreOp: info.stencil ? 'discard' : undefined,
-        },
-      });
-      pass.setPipeline(testPipeline);
-      pass.setBindGroup(0, testBindGroup);
-      pass.setViewport(0, 0, kNumTestPoints, 1, kViewportMinDepth, kViewportMaxDepth);
-      pass.draw(kNumTestPoints);
-      pass.end();
-    }
-    if (dsActual) {
-      enc.copyTextureToBuffer({ texture: dsTexture, aspect: 'depth-only' }, { buffer: dsActual }, [
-        kNumTestPoints,
-      ]);
-    }
-    {
-      const clearValue = [0, 0, 0, 0]; // Will see this color if the check passed.
-      const pass = enc.beginRenderPass({
-        colorAttachments: [
-          checkTextureMSView
-            ? {
-                view: checkTextureMSView,
-                resolveTarget: checkTextureView,
-                clearValue,
-                loadOp: 'clear',
-                storeOp: 'discard',
-              }
-            : { view: checkTextureView, clearValue, loadOp: 'clear', storeOp: 'store' },
-        ],
-        depthStencilAttachment: {
-          view: dsTextureView,
-          depthLoadOp: 'load',
-          depthStoreOp: 'store',
-          stencilClearValue: info.stencil ? 0 : undefined,
-          stencilLoadOp: info.stencil ? 'clear' : undefined,
-          stencilStoreOp: info.stencil ? 'discard' : undefined,
-        },
-      });
-      pass.setPipeline(checkPipeline);
-      pass.setViewport(0, 0, kNumTestPoints, 1, 0.0, 1.0);
-      pass.draw(kNumTestPoints);
-      pass.end();
-    }
-    enc.copyTextureToBuffer({ texture: checkTexture }, { buffer: checkBuffer }, [kNumTestPoints]);
-    if (dsExpected) {
-      enc.copyTextureToBuffer(
-        { texture: dsTexture, aspect: 'depth-only' },
-        { buffer: dsExpected },
-        [kNumTestPoints]
-      );
-    }
-    t.device.queue.submit([enc.finish()]);
+    // const enc = t.device.createCommandEncoder();
+    // {
+    //   const pass = enc.beginRenderPass({
+    //     colorAttachments: [],
+    //     depthStencilAttachment: {
+    //       view: dsTextureView,
+    //       depthClearValue: 0.5, // Will see this depth value if the fragment was clipped.
+    //       depthLoadOp: 'clear',
+    //       depthStoreOp: 'store',
+    //       stencilClearValue: info.stencil ? 0 : undefined,
+    //       stencilLoadOp: info.stencil ? 'clear' : undefined,
+    //       stencilStoreOp: info.stencil ? 'discard' : undefined,
+    //     },
+    //   });
+    //   pass.setPipeline(testPipeline);
+    //   pass.setBindGroup(0, testBindGroup);
+    //   pass.setViewport(0, 0, kNumTestPoints, 1, kViewportMinDepth, kViewportMaxDepth);
+    //   pass.draw(kNumTestPoints);
+    //   pass.end();
+    // }
+    // if (dsActual) {
+    //   enc.copyTextureToBuffer({ texture: dsTexture, aspect: 'depth-only' }, { buffer: dsActual }, [
+    //     kNumTestPoints,
+    //   ]);
+    // }
+    // {
+    //   const clearValue = [0, 0, 0, 0]; // Will see this color if the check passed.
+    //   const pass = enc.beginRenderPass({
+    //     colorAttachments: [
+    //       checkTextureMSView
+    //         ? {
+    //             view: checkTextureMSView,
+    //             resolveTarget: checkTextureView,
+    //             clearValue,
+    //             loadOp: 'clear',
+    //             storeOp: 'discard',
+    //           }
+    //         : { view: checkTextureView, clearValue, loadOp: 'clear', storeOp: 'store' },
+    //     ],
+    //     depthStencilAttachment: {
+    //       view: dsTextureView,
+    //       depthLoadOp: 'load',
+    //       depthStoreOp: 'store',
+    //       stencilClearValue: info.stencil ? 0 : undefined,
+    //       stencilLoadOp: info.stencil ? 'clear' : undefined,
+    //       stencilStoreOp: info.stencil ? 'discard' : undefined,
+    //     },
+    //   });
+    //   pass.setPipeline(checkPipeline);
+    //   pass.setViewport(0, 0, kNumTestPoints, 1, 0.0, 1.0);
+    //   pass.draw(kNumTestPoints);
+    //   pass.end();
+    // }
+    // enc.copyTextureToBuffer({ texture: checkTexture }, { buffer: checkBuffer }, [kNumTestPoints]);
+    // if (dsExpected) {
+    //   enc.copyTextureToBuffer(
+    //     { texture: dsTexture, aspect: 'depth-only' },
+    //     { buffer: dsExpected },
+    //     [kNumTestPoints]
+    //   );
+    // }
+    // t.device.queue.submit([enc.finish()]);
 
-    t.expectGPUBufferValuesPassCheck(
-      fragInputZFailedBuffer,
-      a => checkElementsBetween(a, [() => -1e-5, () => 1e-5]),
-      { type: Float32Array, typedLength: kNumTestPoints }
-    );
+    // t.expectGPUBufferValuesPassCheck(
+    //   fragInputZFailedBuffer,
+    //   a => checkElementsBetween(a, [() => -1e-5, () => 1e-5]),
+    //   { type: Float32Array, typedLength: kNumTestPoints }
+    // );
 
-    const kCheckPassedValue = 0;
-    const predicatePrinter: CheckElementsSupplementalTableRows = [
-      { leftHeader: 'expected ==', getValueForCell: _index => kCheckPassedValue },
-    ];
-    if (dsActual && dsExpected && format === 'depth32float') {
-      t.fail('depth32float unsupported');
-      return;
-      // await Promise.all([dsActual.mapAsync(GPUMapMode.READ), dsExpected.mapAsync(GPUMapMode.READ)]);
-      // const act = new Float32Array(dsActual.getMappedRange());
-      // const exp = new Float32Array(dsExpected.getMappedRange());
-      // predicatePrinter.push(
-      //   { leftHeader: 'act ==', getValueForCell: index => act[index].toFixed(2) },
-      //   { leftHeader: 'exp ==', getValueForCell: index => exp[index].toFixed(2) }
-      // );
-    }
-    t.expectGPUBufferValuesPassCheck(
-      checkBuffer,
-      a =>
-        checkElementsPassPredicate(a, (_index, value) => value === kCheckPassedValue, {
-          predicatePrinter,
-        }),
-      { type: Uint8Array, typedLength: kNumTestPoints, method: 'map' }
-    );
+    // const kCheckPassedValue = 0;
+    // const predicatePrinter: CheckElementsSupplementalTableRows = [
+    //   { leftHeader: 'expected ==', getValueForCell: _index => kCheckPassedValue },
+    // ];
+    // if (dsActual && dsExpected && format === 'depth32float') {
+    //   t.fail('depth32float unsupported');
+    //   return;
+    //   // await Promise.all([dsActual.mapAsync(GPUMapMode.READ), dsExpected.mapAsync(GPUMapMode.READ)]);
+    //   // const act = new Float32Array(dsActual.getMappedRange());
+    //   // const exp = new Float32Array(dsExpected.getMappedRange());
+    //   // predicatePrinter.push(
+    //   //   { leftHeader: 'act ==', getValueForCell: index => act[index].toFixed(2) },
+    //   //   { leftHeader: 'exp ==', getValueForCell: index => exp[index].toFixed(2) }
+    //   // );
+    // }
+    // t.expectGPUBufferValuesPassCheck(
+    //   checkBuffer,
+    //   a =>
+    //     checkElementsPassPredicate(a, (_index, value) => value === kCheckPassedValue, {
+    //       predicatePrinter,
+    //     }),
+    //   { type: Uint8Array, typedLength: kNumTestPoints, method: 'map' }
+    // );
   });
 
 g.test('depth_test_input_clamped')
@@ -369,166 +370,167 @@ to be empty.`
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
 
-    t.selectDeviceOrSkipTestCase([
-      t.params.unclippedDepth ? 'depth-clip-control' : undefined,
-      info.feature,
-    ]);
+    // t.selectDeviceOrSkipTestCase([
+    //   t.params.unclippedDepth ? 'depth-clip-control' : undefined,
+    //   info.feature,
+    // ]);
   })
   .fn(t => {
-    const { format, unclippedDepth, multisampled } = t.params;
-    const info = kTextureFormatInfo[format];
+    t.fail('depth_test_input_clamped not supported');
+    // const { format, unclippedDepth, multisampled } = t.params;
+    // const info = kTextureFormatInfo[format];
 
-    const kNumDepthValues = 8;
-    const kViewportMinDepth = 0.25;
-    const kViewportMaxDepth = 0.75;
+    // const kNumDepthValues = 8;
+    // const kViewportMinDepth = 0.25;
+    // const kViewportMaxDepth = 0.75;
 
-    const shaderSource = `
-      // Test depths, with viewport range corresponding to [0,1].
-      var<private> kDepths: array<f32, ${kNumDepthValues}> = array<f32, ${kNumDepthValues}>(
-          -1.0, -0.5, 0.0, 0.25, 0.75, 1.0, 1.5, 2.0);
+    // const shaderSource = `
+    //   // Test depths, with viewport range corresponding to [0,1].
+    //   var<private> kDepths: array<f32, ${kNumDepthValues}> = array<f32, ${kNumDepthValues}>(
+    //       -1.0, -0.5, 0.0, 0.25, 0.75, 1.0, 1.5, 2.0);
 
-      const vpMin: f32 = ${kViewportMinDepth};
-      const vpMax: f32 = ${kViewportMaxDepth};
+    //   const vpMin: f32 = ${kViewportMinDepth};
+    //   const vpMax: f32 = ${kViewportMaxDepth};
 
-      // Draw the points in a straight horizontal row, one per pixel.
-      fn vertexX(idx: u32) -> f32 {
-        return (f32(idx) + 0.5) * 2.0 / ${kNumDepthValues}.0 - 1.0;
-      }
+    //   // Draw the points in a straight horizontal row, one per pixel.
+    //   fn vertexX(idx: u32) -> f32 {
+    //     return (f32(idx) + 0.5) * 2.0 / ${kNumDepthValues}.0 - 1.0;
+    //   }
 
-      struct VF {
-        @builtin(position) pos: vec4<f32>,
-        @location(0) @interpolate(flat, either) vertexIndex: u32,
-      };
+    //   struct VF {
+    //     @builtin(position) pos: vec4<f32>,
+    //     @location(0) @interpolate(flat, either) vertexIndex: u32,
+    //   };
 
-      @vertex
-      fn vmain(@builtin(vertex_index) idx: u32) -> VF {
-        var vf: VF;
-        // Depth=0.5 because we want to render every point, not get clipped.
-        vf.pos = vec4<f32>(vertexX(idx), 0.0, 0.5, 1.0);
-        vf.vertexIndex = idx;
-        return vf;
-      }
+    //   @vertex
+    //   fn vmain(@builtin(vertex_index) idx: u32) -> VF {
+    //     var vf: VF;
+    //     // Depth=0.5 because we want to render every point, not get clipped.
+    //     vf.pos = vec4<f32>(vertexX(idx), 0.0, 0.5, 1.0);
+    //     vf.vertexIndex = idx;
+    //     return vf;
+    //   }
 
-      @fragment
-      fn finit(vf: VF) -> @builtin(frag_depth) f32 {
-        // Expected values of the ftest pipeline.
-        return clamp(kDepths[vf.vertexIndex], vpMin, vpMax);
-      }
+    //   @fragment
+    //   fn finit(vf: VF) -> @builtin(frag_depth) f32 {
+    //     // Expected values of the ftest pipeline.
+    //     return clamp(kDepths[vf.vertexIndex], vpMin, vpMax);
+    //   }
 
-      struct FTest {
-        @builtin(frag_depth) depth: f32,
-        @location(0) color: f32,
-      };
+    //   struct FTest {
+    //     @builtin(frag_depth) depth: f32,
+    //     @location(0) color: f32,
+    //   };
 
-      @fragment
-      fn ftest(vf: VF) -> FTest {
-        var f: FTest;
-        f.depth = kDepths[vf.vertexIndex]; // Should get clamped to the viewport.
-        f.color = 1.0; // Color written if the resulting depth is unexpected.
-        return f;
-      }
-    `;
+    //   @fragment
+    //   fn ftest(vf: VF) -> FTest {
+    //     var f: FTest;
+    //     f.depth = kDepths[vf.vertexIndex]; // Should get clamped to the viewport.
+    //     f.color = 1.0; // Color written if the resulting depth is unexpected.
+    //     return f;
+    //   }
+    // `;
 
-    const module = t.device.createShaderModule({ code: shaderSource });
+    // const module = t.device.createShaderModule({ code: shaderSource });
 
-    // Initialize depth attachment with expected values, in [0.25,0.75].
-    const initPipeline = t.device.createRenderPipeline({
-      layout: 'auto',
-      vertex: { module, entryPoint: 'vmain' },
-      primitive: { topology: 'point-list' },
-      depthStencil: { format, depthWriteEnabled: true, depthCompare: 'always' },
-      multisample: multisampled ? { count: 4 } : undefined,
-      fragment: { module, entryPoint: 'finit', targets: [] },
-    });
+    // // Initialize depth attachment with expected values, in [0.25,0.75].
+    // const initPipeline = t.device.createRenderPipeline({
+    //   layout: 'auto',
+    //   vertex: { module, entryPoint: 'vmain' },
+    //   primitive: { topology: 'point-list' },
+    //   depthStencil: { format, depthWriteEnabled: true, depthCompare: 'always' },
+    //   multisample: multisampled ? { count: 4 } : undefined,
+    //   fragment: { module, entryPoint: 'finit', targets: [] },
+    // });
 
-    // With a viewport set to [0.25,0.75], output values in [0.0,1.0] and check they're clamped
-    // before the depth test, regardless of whether unclippedDepth is enabled.
-    const testPipeline = t.device.createRenderPipeline({
-      layout: 'auto',
-      vertex: { module, entryPoint: 'vmain' },
-      primitive: {
-        topology: 'point-list',
-        unclippedDepth,
-      },
-      depthStencil: { format, depthCompare: 'not-equal', depthWriteEnabled: false },
-      multisample: multisampled ? { count: 4 } : undefined,
-      fragment: { module, entryPoint: 'ftest', targets: [{ format: 'r8unorm' }] },
-    });
+    // // With a viewport set to [0.25,0.75], output values in [0.0,1.0] and check they're clamped
+    // // before the depth test, regardless of whether unclippedDepth is enabled.
+    // const testPipeline = t.device.createRenderPipeline({
+    //   layout: 'auto',
+    //   vertex: { module, entryPoint: 'vmain' },
+    //   primitive: {
+    //     topology: 'point-list',
+    //     unclippedDepth,
+    //   },
+    //   depthStencil: { format, depthCompare: 'not-equal', depthWriteEnabled: false },
+    //   multisample: multisampled ? { count: 4 } : undefined,
+    //   fragment: { module, entryPoint: 'ftest', targets: [{ format: 'r8unorm' }] },
+    // });
 
-    const dsTexture = t.createTextureTracked({
-      format,
-      size: [kNumDepthValues],
-      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
-      sampleCount: multisampled ? 4 : 1,
-    });
-    const dsTextureView = dsTexture.createView();
+    // const dsTexture = t.createTextureTracked({
+    //   format,
+    //   size: [kNumDepthValues],
+    //   usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    //   sampleCount: multisampled ? 4 : 1,
+    // });
+    // const dsTextureView = dsTexture.createView();
 
-    const testTextureDesc = {
-      format: 'r8unorm' as const,
-      size: [kNumDepthValues],
-      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
-    };
-    const testTexture = t.createTextureTracked(testTextureDesc);
-    const testTextureView = testTexture.createView();
-    const testTextureMSView = multisampled
-      ? t.createTextureTracked({ ...testTextureDesc, sampleCount: 4 }).createView()
-      : undefined;
+    // const testTextureDesc = {
+    //   format: 'r8unorm' as const,
+    //   size: [kNumDepthValues],
+    //   usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    // };
+    // const testTexture = t.createTextureTracked(testTextureDesc);
+    // const testTextureView = testTexture.createView();
+    // const testTextureMSView = multisampled
+    //   ? t.createTextureTracked({ ...testTextureDesc, sampleCount: 4 }).createView()
+    //   : undefined;
 
-    const resultBuffer = t.createBufferTracked({
-      size: kNumDepthValues,
-      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
-    });
+    // const resultBuffer = t.createBufferTracked({
+    //   size: kNumDepthValues,
+    //   usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+    // });
 
-    const enc = t.device.createCommandEncoder();
-    {
-      const pass = enc.beginRenderPass({
-        colorAttachments: [],
-        depthStencilAttachment: {
-          view: dsTextureView,
-          depthClearValue: 1.0,
-          depthLoadOp: 'clear',
-          depthStoreOp: 'store',
-          stencilClearValue: info.stencil ? 0 : undefined,
-          stencilLoadOp: info.stencil ? 'clear' : undefined,
-          stencilStoreOp: info.stencil ? 'discard' : undefined,
-        },
-      });
-      pass.setPipeline(initPipeline);
-      pass.draw(kNumDepthValues);
-      pass.end();
-    }
-    {
-      const clearValue = [0, 0, 0, 0]; // Will see this color if the test passed.
-      const pass = enc.beginRenderPass({
-        colorAttachments: [
-          testTextureMSView
-            ? {
-                view: testTextureMSView,
-                resolveTarget: testTextureView,
-                clearValue,
-                loadOp: 'clear',
-                storeOp: 'discard',
-              }
-            : { view: testTextureView, clearValue, loadOp: 'clear', storeOp: 'store' },
-        ],
-        depthStencilAttachment: {
-          view: dsTextureView,
-          depthLoadOp: 'load',
-          depthStoreOp: 'store',
-          stencilClearValue: info.stencil ? 0 : undefined,
-          stencilLoadOp: info.stencil ? 'clear' : undefined,
-          stencilStoreOp: info.stencil ? 'discard' : undefined,
-        },
-      });
-      pass.setPipeline(testPipeline);
-      pass.setViewport(0, 0, kNumDepthValues, 1, kViewportMinDepth, kViewportMaxDepth);
-      pass.draw(kNumDepthValues);
-      pass.end();
-    }
-    enc.copyTextureToBuffer({ texture: testTexture }, { buffer: resultBuffer }, [kNumDepthValues]);
-    t.device.queue.submit([enc.finish()]);
+    // const enc = t.device.createCommandEncoder();
+    // {
+    //   const pass = enc.beginRenderPass({
+    //     colorAttachments: [],
+    //     depthStencilAttachment: {
+    //       view: dsTextureView,
+    //       depthClearValue: 1.0,
+    //       depthLoadOp: 'clear',
+    //       depthStoreOp: 'store',
+    //       stencilClearValue: info.stencil ? 0 : undefined,
+    //       stencilLoadOp: info.stencil ? 'clear' : undefined,
+    //       stencilStoreOp: info.stencil ? 'discard' : undefined,
+    //     },
+    //   });
+    //   pass.setPipeline(initPipeline);
+    //   pass.draw(kNumDepthValues);
+    //   pass.end();
+    // }
+    // {
+    //   const clearValue = [0, 0, 0, 0]; // Will see this color if the test passed.
+    //   const pass = enc.beginRenderPass({
+    //     colorAttachments: [
+    //       testTextureMSView
+    //         ? {
+    //             view: testTextureMSView,
+    //             resolveTarget: testTextureView,
+    //             clearValue,
+    //             loadOp: 'clear',
+    //             storeOp: 'discard',
+    //           }
+    //         : { view: testTextureView, clearValue, loadOp: 'clear', storeOp: 'store' },
+    //     ],
+    //     depthStencilAttachment: {
+    //       view: dsTextureView,
+    //       depthLoadOp: 'load',
+    //       depthStoreOp: 'store',
+    //       stencilClearValue: info.stencil ? 0 : undefined,
+    //       stencilLoadOp: info.stencil ? 'clear' : undefined,
+    //       stencilStoreOp: info.stencil ? 'discard' : undefined,
+    //     },
+    //   });
+    //   pass.setPipeline(testPipeline);
+    //   pass.setViewport(0, 0, kNumDepthValues, 1, kViewportMinDepth, kViewportMaxDepth);
+    //   pass.draw(kNumDepthValues);
+    //   pass.end();
+    // }
+    // enc.copyTextureToBuffer({ texture: testTexture }, { buffer: resultBuffer }, [kNumDepthValues]);
+    // t.device.queue.submit([enc.finish()]);
 
-    t.expectGPUBufferValuesEqual(resultBuffer, new Uint8Array(kNumDepthValues), 0, {
-      method: 'map',
-    });
+    // t.expectGPUBufferValuesEqual(resultBuffer, new Uint8Array(kNumDepthValues), 0, {
+    //   method: 'map',
+    // });
   });

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -348,11 +348,16 @@ Params:
       .expand('base_vertex', p => (p.indexed ? ([0, 9] as const) : [undefined]))
   )
   .beforeAllSubcases(t => {
-    if (t.params.first_instance > 0 && t.params.indirect) {
-      t.selectDeviceOrSkipTestCase('indirect-first-instance');
-    }
+    // if (t.params.first_instance > 0 && t.params.indirect) {
+    //   t.selectDeviceOrSkipTestCase('indirect-first-instance');
+    // }
   })
   .fn(t => {
+    if (t.params.base_vertex === 9 || t.params.first_instance > 0) {
+      t.fail('draw not supported for params');
+      return;
+    }
+
     t.checkTriangleDraw({
       firstIndex: t.params.first,
       count: t.params.count,
@@ -387,21 +392,22 @@ g.test('default_arguments')
       )
   )
   .fn(t => {
-    const kVertexCount = 3;
-    const kVertexBufferOffset = 32;
-    const kIndexBufferOffset = 16;
+    t.fail('default arguments not supported');
+    // const kVertexCount = 3;
+    // const kVertexBufferOffset = 32;
+    // const kIndexBufferOffset = 16;
 
-    t.checkTriangleDraw({
-      firstIndex: t.params.first_index,
-      count: kVertexCount,
-      firstInstance: t.params.first_instance,
-      instanceCount: t.params.instance_count,
-      indexed: t.params.mode === 'drawIndexed',
-      indirect: false, // indirect
-      vertexBufferOffset: kVertexBufferOffset,
-      indexBufferOffset: kIndexBufferOffset,
-      baseVertex: t.params.base_vertex,
-    });
+    // t.checkTriangleDraw({
+    //   firstIndex: t.params.first_index,
+    //   count: kVertexCount,
+    //   firstInstance: t.params.first_instance,
+    //   instanceCount: t.params.instance_count,
+    //   indexed: t.params.mode === 'drawIndexed',
+    //   indirect: false, // indirect
+    //   vertexBufferOffset: kVertexBufferOffset,
+    //   indexBufferOffset: kIndexBufferOffset,
+    //   baseVertex: t.params.base_vertex,
+    // });
   });
 
 g.test('vertex_attributes,basic')

--- a/src/webgpu/api/operation/rendering/stencil.spec.ts
+++ b/src/webgpu/api/operation/rendering/stencil.spec.ts
@@ -301,9 +301,15 @@ g.test('stencil_compare_func')
       ] as const)
   )
   .beforeAllSubcases(t => {
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    if (t.params.format !== 'depth32float-stencil8')
+      t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
+    if (t.params.format === 'depth32float-stencil8') {
+      t.fail('stencil format causes crash');
+      return;
+    }
+
     const { format, stencilCompare, stencilRefValue, _expectedColor } = t.params;
 
     t.checkStencilCompareFunction(format, stencilCompare, stencilRefValue, _expectedColor);
@@ -339,9 +345,15 @@ g.test('stencil_passOp_operation')
       ] as const)
   )
   .beforeAllSubcases(t => {
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    if (t.params.format !== 'depth32float-stencil8')
+      t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
+    if (t.params.format === 'depth32float-stencil8') {
+      t.fail('stencil format causes crash');
+      return;
+    }
+
     const { format, passOp, initialStencil, _expectedStencil } = t.params;
 
     const stencilState = {
@@ -384,9 +396,14 @@ g.test('stencil_failOp_operation')
       ] as const)
   )
   .beforeAllSubcases(t => {
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    if (t.params.format !== 'depth32float-stencil8')
+      t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
+    if (t.params.format === 'depth32float-stencil8') {
+      t.fail('stencil format causes crash');
+      return;
+    }
     const { format, failOp, initialStencil, _expectedStencil } = t.params;
 
     const stencilState = {
@@ -438,9 +455,14 @@ g.test('stencil_depthFailOp_operation')
       ] as const)
   )
   .beforeAllSubcases(t => {
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    if (t.params.format !== 'depth32float-stencil8')
+      t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
+    if (t.params.format === 'depth32float-stencil8') {
+      t.fail('stencil format causes crash');
+      return;
+    }
     const { format, depthFailOp, initialStencil, _expectedStencil } = t.params;
 
     const stencilState = {
@@ -484,9 +506,14 @@ g.test('stencil_read_write_mask')
       ])
   )
   .beforeAllSubcases(t => {
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    if (t.params.format !== 'depth32float-stencil8')
+      t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
+    if (t.params.format === 'depth32float-stencil8') {
+      t.fail('stencil format causes crash');
+      return;
+    }
     const { format, maskType, stencilRefValue, _expectedColor } = t.params;
 
     const baseStencilState = {
@@ -534,9 +561,14 @@ g.test('stencil_reference_initialized')
   .desc('Test that stencil reference is initialized as zero for new render pass.')
   .params(u => u.combine('format', kStencilFormats))
   .beforeAllSubcases(t => {
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    if (t.params.format !== 'depth32float-stencil8')
+      t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
+    if (t.params.format === 'depth32float-stencil8') {
+      t.fail('stencil format causes crash');
+      return;
+    }
     const { format } = t.params;
 
     const baseStencilState = {

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -43,70 +43,71 @@ g.test('uninitialized_texture_is_zero')
   .params(kTestParams)
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceOrSkipTestCase(kTextureFormatInfo[t.params.format].feature);
+    // t.selectDeviceOrSkipTestCase(kTextureFormatInfo[t.params.format].feature);
   })
   .fn(t => {
-    const usage = getRequiredTextureUsage(
-      t.params.format,
-      t.params.sampleCount,
-      t.params.uninitializeMethod,
-      t.params.readMethod
-    );
+    t.fail('Test crashes with stencil formats');
+    // const usage = getRequiredTextureUsage(
+    //   t.params.format,
+    //   t.params.sampleCount,
+    //   t.params.uninitializeMethod,
+    //   t.params.readMethod
+    // );
 
-    const texture = t.createTextureTracked({
-      size: [t.textureWidth, t.textureHeight, t.textureDepthOrArrayLayers],
-      format: t.params.format,
-      dimension: t.params.dimension,
-      usage,
-      mipLevelCount: t.params.mipLevelCount,
-      sampleCount: t.params.sampleCount,
-    });
+    // const texture = t.createTextureTracked({
+    //   size: [t.textureWidth, t.textureHeight, t.textureDepthOrArrayLayers],
+    //   format: t.params.format,
+    //   dimension: t.params.dimension,
+    //   usage,
+    //   mipLevelCount: t.params.mipLevelCount,
+    //   sampleCount: t.params.sampleCount,
+    // });
 
-    if (t.params.canaryOnCreation) {
-      // Initialize some subresources with canary values
-      for (const subresourceRange of t.iterateInitializedSubresources()) {
-        t.initializeTexture(texture, InitializedState.Canary, subresourceRange);
-      }
-    }
+    // if (t.params.canaryOnCreation) {
+    //   // Initialize some subresources with canary values
+    //   for (const subresourceRange of t.iterateInitializedSubresources()) {
+    //     t.initializeTexture(texture, InitializedState.Canary, subresourceRange);
+    //   }
+    // }
 
-    switch (t.params.uninitializeMethod) {
-      case UninitializeMethod.Creation:
-        break;
-      case UninitializeMethod.StoreOpClear:
-        // Initialize the rest of the resources.
-        for (const subresourceRange of t.iterateUninitializedSubresources()) {
-          t.initializeTexture(texture, InitializedState.Canary, subresourceRange);
-        }
-        // Then use a store op to discard their contents.
-        for (const subresourceRange of t.iterateUninitializedSubresources()) {
-          t.discardTexture(texture, subresourceRange);
-        }
-        break;
-      default:
-        unreachable();
-    }
+    // switch (t.params.uninitializeMethod) {
+    //   case UninitializeMethod.Creation:
+    //     break;
+    //   case UninitializeMethod.StoreOpClear:
+    //     // Initialize the rest of the resources.
+    //     for (const subresourceRange of t.iterateUninitializedSubresources()) {
+    //       t.initializeTexture(texture, InitializedState.Canary, subresourceRange);
+    //     }
+    //     // Then use a store op to discard their contents.
+    //     for (const subresourceRange of t.iterateUninitializedSubresources()) {
+    //       t.discardTexture(texture, subresourceRange);
+    //     }
+    //     break;
+    //   default:
+    //     unreachable();
+    // }
 
-    // Check that all uninitialized resources are zero.
-    for (const subresourceRange of t.iterateUninitializedSubresources()) {
-      checkContentsImpl[t.params.readMethod](
-        t,
-        t.params,
-        texture,
-        InitializedState.Zero,
-        subresourceRange
-      );
-    }
+    // // Check that all uninitialized resources are zero.
+    // for (const subresourceRange of t.iterateUninitializedSubresources()) {
+    //   checkContentsImpl[t.params.readMethod](
+    //     t,
+    //     t.params,
+    //     texture,
+    //     InitializedState.Zero,
+    //     subresourceRange
+    //   );
+    // }
 
-    if (t.params.canaryOnCreation) {
-      // Check the all other resources are unchanged.
-      for (const subresourceRange of t.iterateInitializedSubresources()) {
-        checkContentsImpl[t.params.readMethod](
-          t,
-          t.params,
-          texture,
-          InitializedState.Canary,
-          subresourceRange
-        );
-      }
-    }
+    // if (t.params.canaryOnCreation) {
+    //   // Check the all other resources are unchanged.
+    //   for (const subresourceRange of t.iterateInitializedSubresources()) {
+    //     checkContentsImpl[t.params.readMethod](
+    //       t,
+    //       t.params,
+    //       texture,
+    //       InitializedState.Canary,
+    //       subresourceRange
+    //     );
+    //   }
+    // }
   });

--- a/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
+++ b/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
@@ -90,36 +90,37 @@ g.test('getCompilationInfo_returns')
   )
   .params(u => u.combineWithParams(kAllShaderSources))
   .fn(async t => {
-    const { _code, valid } = t.params;
+    t.fail('shader_module line_number_and_position validation fails');
+    // const { _code, valid } = t.params;
 
-    const shaderModule = t.expectGPUError(
-      'validation',
-      () => {
-        return t.device.createShaderModule({ code: _code });
-      },
-      !valid
-    );
+    // const shaderModule = t.expectGPUError(
+    //   'validation',
+    //   () => {
+    //     return t.device.createShaderModule({ code: _code });
+    //   },
+    //   !valid
+    // );
 
-    const info = await shaderModule.getCompilationInfo();
+    // const info = await shaderModule.getCompilationInfo();
 
-    t.expect(
-      info instanceof GPUCompilationInfo,
-      'Expected a GPUCompilationInfo object to be returned'
-    );
+    // t.expect(
+    //   info instanceof GPUCompilationInfo,
+    //   'Expected a GPUCompilationInfo object to be returned'
+    // );
 
-    // Expect that we get zero error messages from a valid shader.
-    // Message types other than errors are OK.
-    let errorCount = 0;
-    for (const message of info.messages) {
-      if (message.type === 'error') {
-        errorCount++;
-      }
-    }
-    if (valid) {
-      t.expect(errorCount === 0, "Expected zero GPUCompilationMessages of type 'error'");
-    } else {
-      t.expect(errorCount > 0, "Expected at least one GPUCompilationMessages of type 'error'");
-    }
+    // // Expect that we get zero error messages from a valid shader.
+    // // Message types other than errors are OK.
+    // let errorCount = 0;
+    // for (const message of info.messages) {
+    //   if (message.type === 'error') {
+    //     errorCount++;
+    //   }
+    // }
+    // if (valid) {
+    //   t.expect(errorCount === 0, "Expected zero GPUCompilationMessages of type 'error'");
+    // } else {
+    //   t.expect(errorCount > 0, "Expected at least one GPUCompilationMessages of type 'error'");
+    // }
   });
 
 g.test('line_number_and_position')
@@ -133,46 +134,47 @@ g.test('line_number_and_position')
   )
   .params(u => u.combineWithParams(kInvalidShaderSources))
   .fn(async t => {
-    const { _code, _errorLine, _errorLinePos } = t.params;
+    t.fail('shader_module line_number_and_position validation fails');
+    // const { _code, _errorLine, _errorLinePos } = t.params;
 
-    const shaderModule = t.expectGPUError('validation', () => {
-      return t.device.createShaderModule({ code: _code });
-    });
+    // const shaderModule = t.expectGPUError('validation', () => {
+    //   return t.device.createShaderModule({ code: _code });
+    // });
 
-    const info = await shaderModule.getCompilationInfo();
+    // const info = await shaderModule.getCompilationInfo();
 
-    let foundAppropriateError = false;
-    for (const message of info.messages) {
-      if (message.type === 'error') {
-        // Some backends may not be able to indicate a precise location for the error. In those
-        // cases a line and position of 0 should be reported.
-        // If a line is reported, it should point at the correct line (1-based).
-        t.expect(
-          (message.lineNum === 0) === (message.linePos === 0),
-          `Got message.lineNum ${message.lineNum}, .linePos ${message.linePos}, but GPUCompilationMessage should specify both or neither`
-        );
+    // let foundAppropriateError = false;
+    // for (const message of info.messages) {
+    //   if (message.type === 'error') {
+    //     // Some backends may not be able to indicate a precise location for the error. In those
+    //     // cases a line and position of 0 should be reported.
+    //     // If a line is reported, it should point at the correct line (1-based).
+    //     t.expect(
+    //       (message.lineNum === 0) === (message.linePos === 0),
+    //       `Got message.lineNum ${message.lineNum}, .linePos ${message.linePos}, but GPUCompilationMessage should specify both or neither`
+    //     );
 
-        if (message.lineNum === 0) {
-          foundAppropriateError = true;
-          break;
-        }
+    //     if (message.lineNum === 0) {
+    //       foundAppropriateError = true;
+    //       break;
+    //     }
 
-        if (message.lineNum === _errorLine) {
-          foundAppropriateError = true;
-          if (_errorLinePos !== undefined) {
-            t.expect(
-              message.linePos === _errorLinePos,
-              `Got message.linePos ${message.linePos}, expected ${_errorLinePos}`
-            );
-          }
-          break;
-        }
-      }
-    }
-    t.expect(
-      foundAppropriateError,
-      'Expected to find an error which corresponded with the erroneous line'
-    );
+    //     if (message.lineNum === _errorLine) {
+    //       foundAppropriateError = true;
+    //       if (_errorLinePos !== undefined) {
+    //         t.expect(
+    //           message.linePos === _errorLinePos,
+    //           `Got message.linePos ${message.linePos}, expected ${_errorLinePos}`
+    //         );
+    //       }
+    //       break;
+    //     }
+    //   }
+    // }
+    // t.expect(
+    //   foundAppropriateError,
+    //   'Expected to find an error which corresponded with the erroneous line'
+    // );
   });
 
 g.test('offset_and_length')
@@ -184,40 +186,41 @@ g.test('offset_and_length')
   )
   .params(u => u.combineWithParams(kAllShaderSources))
   .fn(async t => {
-    const { _code, valid } = t.params;
+    t.fail('shader_module offset_and_length validation fails');
+    // const { _code, valid } = t.params;
 
-    const shaderModule = t.expectGPUError(
-      'validation',
-      () => {
-        return t.device.createShaderModule({ code: _code });
-      },
-      !valid
-    );
+    // const shaderModule = t.expectGPUError(
+    //   'validation',
+    //   () => {
+    //     return t.device.createShaderModule({ code: _code });
+    //   },
+    //   !valid
+    // );
 
-    const info = await shaderModule.getCompilationInfo();
+    // const info = await shaderModule.getCompilationInfo();
 
-    for (const message of info.messages) {
-      // Any offsets and lengths should reference valid spans of the shader code.
-      t.expect(
-        message.offset <= _code.length && message.offset + message.length <= _code.length,
-        'message.offset and .length should be within the shader source'
-      );
+    // for (const message of info.messages) {
+    //   // Any offsets and lengths should reference valid spans of the shader code.
+    //   t.expect(
+    //     message.offset <= _code.length && message.offset + message.length <= _code.length,
+    //     'message.offset and .length should be within the shader source'
+    //   );
 
-      // If a valid line number and position are given, the offset should point the the same
-      // location in the shader source.
-      if (message.lineNum !== 0 && message.linePos !== 0) {
-        let lineOffset = 0;
-        for (let i = 0; i < message.lineNum - 1; ++i) {
-          lineOffset = _code.indexOf('\n', lineOffset);
-          assert(lineOffset !== -1);
-          lineOffset += 1;
-        }
+    //   // If a valid line number and position are given, the offset should point the the same
+    //   // location in the shader source.
+    //   if (message.lineNum !== 0 && message.linePos !== 0) {
+    //     let lineOffset = 0;
+    //     for (let i = 0; i < message.lineNum - 1; ++i) {
+    //       lineOffset = _code.indexOf('\n', lineOffset);
+    //       assert(lineOffset !== -1);
+    //       lineOffset += 1;
+    //     }
 
-        const expectedOffset = lineOffset + message.linePos - 1;
-        t.expect(
-          message.offset === expectedOffset,
-          `message.lineNum (${message.lineNum}) and .linePos (${message.linePos}) point to a different offset (${lineOffset} + ${message.linePos} - 1 = ${expectedOffset}) than .offset (${message.offset})`
-        );
-      }
-    }
+    //     const expectedOffset = lineOffset + message.linePos - 1;
+    //     t.expect(
+    //       message.offset === expectedOffset,
+    //       `message.lineNum (${message.lineNum}) and .linePos (${message.linePos}) point to a different offset (${lineOffset} + ${message.linePos} - 1 = ${expectedOffset}) than .offset (${message.offset})`
+    //     );
+    //   }
+    // }
   });

--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -577,7 +577,7 @@ g.test('basic')
   )
   .beforeAllSubcases(t => {
     if (t.params.format === 'bgra8unorm') {
-      t.selectDeviceOrSkipTestCase('bgra8unorm-storage');
+      t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     }
     if (t.isCompatibility) {
       t.skipIfTextureFormatNotUsableAsStorageTexture(t.params.format);

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -655,24 +655,25 @@ g.test('vertex_format_to_shader_format_conversion')
       ])
   )
   .fn(t => {
-    const { format, shaderComponentCount, slotVariant, shaderLocationVariant } = t.params;
-    const slot = t.makeLimitVariant('maxVertexBuffers', slotVariant);
-    const shaderLocation = t.makeLimitVariant('maxVertexAttributes', shaderLocationVariant);
-    t.runTest([
-      {
-        slot,
-        arrayStride: 16,
-        stepMode: 'vertex',
-        attributes: [
-          {
-            shaderLocation,
-            format,
-            offset: 0,
-            shaderComponentCount,
-          },
-        ],
-      },
-    ]);
+    t.fail('vertex_format_to_shader_format_conversion crashes');
+    // const { format, shaderComponentCount, slotVariant, shaderLocationVariant } = t.params;
+    // const slot = t.makeLimitVariant('maxVertexBuffers', slotVariant);
+    // const shaderLocation = t.makeLimitVariant('maxVertexAttributes', shaderLocationVariant);
+    // t.runTest([
+    //   {
+    //     slot,
+    //     arrayStride: 16,
+    //     stepMode: 'vertex',
+    //     attributes: [
+    //       {
+    //         shaderLocation,
+    //         format,
+    //         offset: 0,
+    //         shaderComponentCount,
+    //       },
+    //     ],
+    //   },
+    // ]);
   });
 
 g.test('setVertexBuffer_offset_and_attribute_offset')
@@ -1127,30 +1128,31 @@ g.test('array_stride_zero')
 g.test('discontiguous_location_and_attribs')
   .desc('Test that using far away slots / shaderLocations works as expected')
   .fn(t => {
-    t.runTest([
-      {
-        slot: t.device.limits.maxVertexBuffers - 1,
-        arrayStride: 4,
-        stepMode: 'vertex',
-        attributes: [
-          { format: 'uint8x2', offset: 2, shaderLocation: 0 },
-          { format: 'uint8x2', offset: 0, shaderLocation: 8 },
-        ],
-      },
-      {
-        slot: 1,
-        arrayStride: 16,
-        stepMode: 'instance',
-        vbOffset: 1000,
-        attributes: [
-          {
-            format: 'uint32x4',
-            offset: 0,
-            shaderLocation: t.device.limits.maxVertexAttributes - 1,
-          },
-        ],
-      },
-    ]);
+    t.fail('discontiguous location and attribs crash');
+    // t.runTest([
+    //   {
+    //     slot: t.device.limits.maxVertexBuffers - 1,
+    //     arrayStride: 4,
+    //     stepMode: 'vertex',
+    //     attributes: [
+    //       { format: 'uint8x2', offset: 2, shaderLocation: 0 },
+    //       { format: 'uint8x2', offset: 0, shaderLocation: 8 },
+    //     ],
+    //   },
+    //   {
+    //     slot: 1,
+    //     arrayStride: 16,
+    //     stepMode: 'instance',
+    //     vbOffset: 1000,
+    //     attributes: [
+    //       {
+    //         format: 'uint32x4',
+    //         offset: 0,
+    //         shaderLocation: t.device.limits.maxVertexAttributes - 1,
+    //       },
+    //     ],
+    //   },
+    // ]);
   });
 
 g.test('overlapping_attributes')

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -230,6 +230,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
           this.skip(`texture format '${format} is not supported`);
         }
       }
+      this.skipIfCopyTextureToTextureNotSupportedForFormat(...formats);
     }
   }
 

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -259,6 +259,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
       if (format && !isTextureFormatUsableAsStorageFormat(format, this.isCompatibility)) {
         this.skip(`Texture with ${format} is not usable as a storage texture`);
       }
+      this.skipIfCopyTextureToTextureNotSupportedForFormat(...formats);
     }
   }
 

--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -81,10 +81,14 @@ export class DevicePool {
       // created for the next test.
       if (!(ex instanceof TestFailedButDeviceReusable)) {
         this.holders.delete(holder);
-        if ('destroy' in holder.device) {
+        if ('destroy' in holder.device && holder.device.destroy) {
+          holder.device.queue.submit([]);
           holder.device.destroy();
           // Wait for destruction (or actual device loss if any) to complete.
           // await holder.device.lost;
+          await new Promise<void>(resolve => {
+            setTimeout(resolve, 5);
+          });
         }
 
         // Release the (hopefully only) ref to the GPUDevice.


### PR DESCRIPTION
This tracks the remaining inventory of crashing tests after fixing react-native-webgpu's promise implementation: https://github.com/wcandillon/react-native-webgpu/pull/129 and upgrading dawn to 6592: https://dawn.googlesource.com/dawn/+/refs/heads/chromium/6592. With these pending upgrades, we should be able to fully track the inventory of failures and skipped tests in `react-native-webgpu`.

Remaining inventory includes stencil rendering and depth test issues uncovered after adding support for the "either" interpolation method and flaky tests within the command_buffer tests.


![Simulator Screenshot - iPhone 15 Pro - 2024-09-27 at 16 35 05](https://github.com/user-attachments/assets/b1c33f42-93e6-4ca1-a8e8-3a4241c2be26)

