### PR TITLE
Disable concurrent subcases in test run

### DIFF
--- a/src/app/runTests.ts
+++ b/src/app/runTests.ts
@@ -9,6 +9,7 @@ import { assert, unreachable } from '../common/util/util';
 const filterQuery = 'webgpu:api,operation,*';
 
 globalTestConfig.compatibility = true;
+globalTestConfig.maxSubcasesInFlight = 1;
 
 export const runTests = async () => {
   const loader = new DefaultTestFileLoader();


### PR DESCRIPTION
When running subcases concurrently on a real device, overlapping metal command encoder usage can cause the app to crash.